### PR TITLE
Consolidation Telemetry Configuration

### DIFF
--- a/.devops/pipeline-main.yml
+++ b/.devops/pipeline-main.yml
@@ -50,6 +50,6 @@ extends:
     sonarExtraProperties: |
       sonar.projectKey=spydersoft_platform
       sonar.inclusions=src/**/*
-      sonar.test.inclusions=src/**/*.UnitTests/**/*;src/**/*.ApiTests/**/*
-      sonar.coverage.exclusions=src/**/*.UnitTests/**/*;src/**/*.ApiTests/**/*
+      sonar.test.inclusions=src/**/*.UnitTests/*;src/**/*.ApiTests/*
+      sonar.coverage.exclusions=src/**/*.UnitTests/*;src/**/*.ApiTests/*
       sonar.scanner.scanAll=false

--- a/.devops/pipeline-main.yml
+++ b/.devops/pipeline-main.yml
@@ -50,6 +50,6 @@ extends:
     sonarExtraProperties: |
       sonar.projectKey=spydersoft_platform
       sonar.inclusions=src/**/*
-      sonar.test.inclusions=src/**/*.UnitTests/*;src/**/*.ApiTests/*
-      sonar.coverage.exclusions=src/**/*.UnitTests/*;src/**/*.ApiTests/*
+      sonar.test.inclusions=src/**/*.UnitTests/**;src/**/*.ApiTests/**
+      sonar.coverage.exclusions=src/**/*.UnitTests/**;src/**/*.ApiTests/**
       sonar.scanner.scanAll=false

--- a/.devops/pipeline-main.yml
+++ b/.devops/pipeline-main.yml
@@ -49,8 +49,6 @@ extends:
     sonarProjectName: Spydersoft.Platform
     sonarExtraProperties: |
       sonar.projectKey=spydersoft_platform
-      sonar.sources=src
-      sonar.tests=src
-      sonar.test.inclusions=src/**/*.UnitTests/**,src/**/*.ApiTests/**
-      sonar.coverage.exclusions=src/**/*.UnitTests/**,src/**/*.ApiTests/**
+      sonar.test.inclusions=**/*.UnitTests/**,**/*.ApiTests/**
+      sonar.coverage.exclusions=**/*.UnitTests/**,**/*.ApiTests/**
       sonar.scanner.scanAll=false

--- a/.devops/pipeline-main.yml
+++ b/.devops/pipeline-main.yml
@@ -49,7 +49,8 @@ extends:
     sonarProjectName: Spydersoft.Platform
     sonarExtraProperties: |
       sonar.projectKey=spydersoft_platform
-      sonar.inclusions=src/**/*
-      sonar.test.inclusions=src/**/*.UnitTests/**;src/**/*.ApiTests/**
-      sonar.coverage.exclusions=src/**/*.UnitTests/**;src/**/*.ApiTests/**
+      sonar.sources=src
+      sonar.tests=src
+      sonar.test.inclusions=src/**/*.UnitTests/**,src/**/*.ApiTests/**
+      sonar.coverage.exclusions=src/**/*.UnitTests/**,src/**/*.ApiTests/**
       sonar.scanner.scanAll=false

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,44 +5,44 @@
 
 	<ItemGroup>
 		<!-- Microsoft Packages -->
-		<PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.8" />
-		<PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.8" />
+		<PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.1" />
+		<PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.1" />
 		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.19" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />
 		
 		<!-- Microsoft.AspNetCore.Authentication.JwtBearer - Framework Specific -->
 		<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />
 		
 		<!-- OpenTelemetry Packages -->
-		<PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+		<PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
+		<PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
+		<PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
+		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
 		
 		<!-- Serilog -->
-		<PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
+		<PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
 		
 		<!-- FusionCache -->
-		<PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.3.0" />
-		<PackageVersion Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.3.0" />
-		<PackageVersion Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.3.0" />
-		<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.3.0" />
+		<PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.5.0" />
+		<PackageVersion Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.5.0" />
+		<PackageVersion Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.5.0" />
+		<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.5.0" />
 		
 		<!-- Third Party -->
 		<PackageVersion Include="NeoSmart.Caching.Sqlite.AspNetCore" Version="9.0.1" />
 		
 		<!-- Test Packages -->
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 		<PackageVersion Include="NUnit" Version="4.4.0" />
-		<PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />
-		<PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
+		<PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="6.0.1" />
 	</ItemGroup>
 </Project>

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Controllers/CacheTestController.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Controllers/CacheTestController.cs
@@ -8,7 +8,7 @@ namespace Spydersoft.Platform.Hosting.ApiTests.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class CacheTestController(IOptions<FusionCacheConfigOptions> options, IFusionCache? cache = null) : ControllerBase
+public class CacheTestController(IFusionCache? cache = null) : ControllerBase
 {
     [HttpGet("{id:int}")]
     public async Task<CacheObjectOne> Get(int id)

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Controllers/TelemetryFunctionsAccessController.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Controllers/TelemetryFunctionsAccessController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Spydersoft.Platform.Hosting.ApiTests.Models;
+using Spydersoft.Platform.Hosting.ApiTests.OptionsTests;
+using Spydersoft.Platform.Hosting.ApiTests.Services;
+
+namespace Spydersoft.Platform.Hosting.ApiTests.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class TelemetryFunctionsAccessController() : ControllerBase
+{
+    [HttpGet()]
+    public TestConfigurationFunctionTrackerData GetTracker()
+    {
+        return TestConfigurationFunctionTracker.Instance.Data;
+    }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Models/TestConfigurationFunctionTrackerData.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Models/TestConfigurationFunctionTrackerData.cs
@@ -1,0 +1,12 @@
+namespace Spydersoft.Platform.Hosting.ApiTests.Models;
+
+public class TestConfigurationFunctionTrackerData
+{
+    public int TraceConfigurationCalled { get; set; }
+    public int MetricsConfigurationCalled { get; set; }
+    public int LogConfigurationCalled { get; set; }
+    public int AspNetFilterFunctionCalled { get; set; }
+    public int AspNetRequestEnrichActionCalled { get; set; }
+    public int AspNetResponseEnrichActionCalled { get; set; }
+    public int AspNetExceptionEnrichActionCalled { get; set; }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Services/TestConfigurationFunctions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Services/TestConfigurationFunctions.cs
@@ -1,0 +1,30 @@
+using Spydersoft.Platform.Hosting.ApiTests.Models;
+
+namespace Spydersoft.Platform.Hosting.ApiTests.Services;
+
+public class TestConfigurationFunctionTracker
+{
+    private static TestConfigurationFunctionTracker? _instance;
+    public static TestConfigurationFunctionTracker Instance
+    {
+        get
+        {
+            _instance ??= new TestConfigurationFunctionTracker();
+            return _instance;
+        }
+    }
+
+    public TestConfigurationFunctionTrackerData Data { get; } = new TestConfigurationFunctionTrackerData();
+
+    public void Reset()
+    {
+        Data.TraceConfigurationCalled = 0;
+        Data.MetricsConfigurationCalled = 0;
+        Data.LogConfigurationCalled = 0;
+        Data.AspNetFilterFunctionCalled = 0;
+        Data.AspNetRequestEnrichActionCalled = 0;
+        Data.AspNetResponseEnrichActionCalled = 0;
+        Data.AspNetExceptionEnrichActionCalled = 0;
+    }
+}
+

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.AdvancedTelemetryConfig.json
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.AdvancedTelemetryConfig.json
@@ -1,0 +1,29 @@
+{
+  "AllowedHosts": "*",
+  "IncludeTelemetryConfigFunctions": true,
+  "Logging": {
+    "OpenTelemetry": {
+      "IncludeFormattedMessage": true,
+      "IncludeScopes": true,
+      "ParseStateValues": true
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": "Information"
+  },
+  "Telemetry": {
+    "Enabled": true,
+    "ActivitySourceName": "Platform.Test.Activity",
+    "MeterName": "Platform.Test.Meter",
+    "ServiceName": "Platform.Test",
+    "Trace": {
+      "Type": "console"
+    },
+    "Metrics": {
+      "Type": "console"
+    },
+    "Log": {
+      "Type": "console"
+    }
+  }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.ConfigurationFunctions.json
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.ConfigurationFunctions.json
@@ -1,0 +1,28 @@
+{
+  "AllowedHosts": "*",
+  "Logging": {
+    "OpenTelemetry": {
+      "IncludeFormattedMessage": true,
+      "IncludeScopes": true,
+      "ParseStateValues": true
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": "Information"
+  },
+  "Telemetry": {
+    "Enabled": true,
+    "ActivitySourceName": "Platform.Test.Activity",
+    "MeterName": "Platform.Test.Meter",
+    "ServiceName": "Platform.Test",
+    "Trace": {
+      "Type": "console"
+    },
+    "Metrics": {
+      "Type": "console"
+    },
+    "Log": {
+      "Type": "console"
+    }
+  }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.ExponentialHistogram.json
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.ExponentialHistogram.json
@@ -1,0 +1,22 @@
+{
+  "AllowedHosts": "*",
+  "Logging": {
+    "OpenTelemetry": {
+      "IncludeFormattedMessage": true,
+      "IncludeScopes": true,
+      "ParseStateValues": true
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": "Information"
+  },
+  "Telemetry": {
+    "ActivitySourceName": "Platform.Test.Activity",
+    "MeterName": "Platform.Test.Meter",
+    "Metrics": {
+      "HistogramAggregation": "exponential",
+      "Type": "console"
+    },
+    "ServiceName": "Platform.Test"
+  }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.OtlpHeaders.json
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.OtlpHeaders.json
@@ -1,0 +1,49 @@
+{
+  "AllowedHosts": "*",
+  "Logging": {
+    "OpenTelemetry": {
+      "IncludeFormattedMessage": true,
+      "IncludeScopes": true,
+      "ParseStateValues": true
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": "Information"
+  },
+  "Telemetry": {
+    "ActivitySourceName": "Platform.Test.Activity",
+    "Log": {
+      "Otlp": {
+        "Endpoint": "http://log.localhost:12345",
+        "Headers": {
+          "Authorization": "Bearer log-token",
+          "X-Custom-Header": "custom-value"
+        },
+        "Protocol": "http"
+      },
+      "Type": "otlp"
+    },
+    "MeterName": "Platform.Test.Meter",
+    "Metrics": {
+      "Otlp": {
+        "Endpoint": "http://metrics.localhost:12345",
+        "Headers": {
+          "Authorization": "Bearer metrics-token"
+        },
+        "Protocol": "http"
+      },
+      "Type": "otlp"
+    },
+    "Trace": {
+      "Otlp": {
+        "Endpoint": "http://trace.localhost:12345",
+        "Headers": {
+          "Authorization": "Bearer trace-token",
+          "X-Trace-Id": "test-trace"
+        }
+      },
+      "Type": "otlp"
+    },
+    "ServiceName": "Platform.Test"
+  }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.TelemetryDisabled.json
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/appsettings.TelemetryDisabled.json
@@ -1,0 +1,19 @@
+{
+  "AllowedHosts": "*",
+  "Logging": {
+    "OpenTelemetry": {
+      "IncludeFormattedMessage": true,
+      "IncludeScopes": true,
+      "ParseStateValues": true
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": "Information"
+  },
+  "Telemetry": {
+    "Enabled": false,
+    "ActivitySourceName": "Platform.Test.Activity",
+    "MeterName": "Platform.Test.Meter",
+    "ServiceName": "Platform.Test"
+  }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsExecutionTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsExecutionTests.cs
@@ -1,0 +1,61 @@
+using Spydersoft.Platform.Hosting.ApiTests.Models;
+using Spydersoft.Platform.Hosting.HealthChecks;
+using Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
+using System.Net;
+using System.Text.Json;
+
+namespace Spydersoft.Platform.Hosting.UnitTests.ApiTests.Telemetry;
+
+public class ConfigurationFunctionsExecutionTests : ApiTestBase
+{
+    public override string Environment => "AdvancedTelemetryConfig";
+
+    [Test]
+    public async Task Startup_ConfigurationFunctionsExecution_ShouldBeHealthy()
+    {
+        var result = await Client.GetAsync($"startup");
+
+        using var jsonResult = JsonDocument.Parse(await result.Content.ReadAsStringAsync());
+
+        var telemetryNode = jsonResult.RootElement;
+
+        var details = telemetryNode.Deserialize<HealthCheckResponseResult>(
+                JsonOptions
+        );
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(details, Is.Not.Null);
+            Assert.That(details?.Status, Is.EqualTo("Healthy"));
+            Assert.That(details?.Results, Contains.Key(nameof(TelemetryHealthCheck)));
+
+            var telemetryHealthCheckResults = details?.Results?[nameof(TelemetryHealthCheck)];
+            Assert.That(telemetryHealthCheckResults, Is.Not.Null);
+            Assert.That(telemetryHealthCheckResults?.Status, Is.EqualTo("Healthy"));
+            Assert.That(telemetryHealthCheckResults?.ResultData, Contains.Key("details"));
+
+            Assert.That(telemetryHealthCheckResults?.ResultData?["details"], Is.TypeOf<TelemetryHealthCheckDetails>());
+            var telemetryData = telemetryHealthCheckResults?.ResultData?["details"] as TelemetryHealthCheckDetails;
+        }
+    }
+
+    [Test]
+    public async Task ConfigurationFunctions_AreExecuted()
+    {
+        // Just make a request to trigger the telemetry functions
+		_ = await Client.GetAsync($"/service");
+
+        var result = await Client.GetAsync($"/TelemetryFunctionsAccess");
+
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        var content = await result.Content.ReadAsStringAsync();
+
+        var functionTrackerData = JsonSerializer.Deserialize<TestConfigurationFunctionTrackerData>(content, JsonOptions);
+        Assert.That(functionTrackerData, Is.Not.Null);
+        Assert.That(functionTrackerData!.AspNetFilterFunctionCalled, Is.GreaterThan(0), "AspNetFilterFunctionCalled should have been called.");
+        Assert.That(functionTrackerData!.AspNetRequestEnrichActionCalled, Is.GreaterThan(0), "AspNetRequestEnrichAction should have been called.");
+        Assert.That(functionTrackerData!.AspNetResponseEnrichActionCalled, Is.GreaterThan(0), "AspNetResponseEnrichAction should have been called.");
+        Assert.That(functionTrackerData!.AspNetExceptionEnrichActionCalled, Is.EqualTo(0), "AspNetExceptionEnrichAction should not have been called.");
+    }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsExecutionTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsExecutionTests.cs
@@ -2,6 +2,7 @@ using Spydersoft.Platform.Hosting.ApiTests.Models;
 using Spydersoft.Platform.Hosting.HealthChecks;
 using Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
 using System.Net;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Spydersoft.Platform.Hosting.UnitTests.ApiTests.Telemetry;
@@ -44,7 +45,7 @@ public class ConfigurationFunctionsExecutionTests : ApiTestBase
     public async Task ConfigurationFunctions_AreExecuted()
     {
         // Just make a request to trigger the telemetry functions
-		_ = await Client.GetAsync($"/service");
+        _ = await Client.GetAsync($"/service");
 
         var result = await Client.GetAsync($"/TelemetryFunctionsAccess");
 
@@ -52,10 +53,14 @@ public class ConfigurationFunctionsExecutionTests : ApiTestBase
         var content = await result.Content.ReadAsStringAsync();
 
         var functionTrackerData = JsonSerializer.Deserialize<TestConfigurationFunctionTrackerData>(content, JsonOptions);
-        Assert.That(functionTrackerData, Is.Not.Null);
-        Assert.That(functionTrackerData!.AspNetFilterFunctionCalled, Is.GreaterThan(0), "AspNetFilterFunctionCalled should have been called.");
-        Assert.That(functionTrackerData!.AspNetRequestEnrichActionCalled, Is.GreaterThan(0), "AspNetRequestEnrichAction should have been called.");
-        Assert.That(functionTrackerData!.AspNetResponseEnrichActionCalled, Is.GreaterThan(0), "AspNetResponseEnrichAction should have been called.");
-        Assert.That(functionTrackerData!.AspNetExceptionEnrichActionCalled, Is.EqualTo(0), "AspNetExceptionEnrichAction should not have been called.");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(functionTrackerData, Is.Not.Null);
+            Assert.That(functionTrackerData!.AspNetFilterFunctionCalled, Is.GreaterThan(0), "AspNetFilterFunctionCalled should have been called.");
+            Assert.That(functionTrackerData!.AspNetRequestEnrichActionCalled, Is.GreaterThan(0), "AspNetRequestEnrichAction should have been called.");
+            Assert.That(functionTrackerData!.AspNetResponseEnrichActionCalled, Is.GreaterThan(0), "AspNetResponseEnrichAction should have been called.");
+            Assert.That(functionTrackerData!.AspNetExceptionEnrichActionCalled, Is.Zero, "AspNetExceptionEnrichAction should not have been called.");
+        }
     }
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using Spydersoft.Platform.Hosting.StartupExtensions;
+using Spydersoft.Platform.Hosting.Telemetry;
+using System.Diagnostics;
+
+namespace Spydersoft.Platform.Hosting.UnitTests.ApiTests.Telemetry;
+
+public class ConfigurationFunctionsTests
+{
+    private bool _traceConfigCalled;
+    private bool _metricsConfigCalled;
+    private bool _logConfigCalled;
+
+    [SetUp]
+    public void Setup()
+    {
+        _traceConfigCalled = false;
+        _metricsConfigCalled = false;
+        _logConfigCalled = false;
+    }
+
+    [Test]
+    public async Task AddSpydersoftTelemetry_WithConfigurationFunctions_ShouldInvokeCallbacks()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        
+        // Add minimal telemetry configuration
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Telemetry:Enabled"] = "true",
+            ["Telemetry:ServiceName"] = "TestService",
+            ["Telemetry:ActivitySourceName"] = "TestActivity",
+            ["Telemetry:MeterName"] = "TestMeter",
+            ["Telemetry:Trace:Type"] = "console",
+            ["Telemetry:Metrics:Type"] = "console",
+            ["Telemetry:Log:Type"] = "console"
+        });
+
+        var configFunctions = new ConfigurationFunctions
+        {
+            TraceConfiguration = (traceBuilder) =>
+            {
+                _traceConfigCalled = true;
+                Assert.That(traceBuilder, Is.Not.Null);
+            },
+            MetricsConfiguration = (metricsBuilder) =>
+            {
+                _metricsConfigCalled = true;
+                Assert.That(metricsBuilder, Is.Not.Null);
+            },
+            LogConfiguration = (logBuilder) =>
+            {
+                _logConfigCalled = true;
+                Assert.That(logBuilder, Is.Not.Null);
+            }
+        };
+
+        // Act
+        builder.AddSpydersoftTelemetry(typeof(ConfigurationFunctionsTests).Assembly, configFunctions);
+        var app = builder.Build();
+
+        // Assert
+        Assert.That(_traceConfigCalled, Is.True, "TraceConfiguration should be called");
+        Assert.That(_metricsConfigCalled, Is.True, "MetricsConfiguration should be called");
+        Assert.That(_logConfigCalled, Is.True, "LogConfiguration should be called");
+
+        await app.DisposeAsync();
+    }
+
+    [Test]
+    public async Task AddSpydersoftTelemetry_WithNullConfigurationFunctions_ShouldNotThrow()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Telemetry:Enabled"] = "true",
+            ["Telemetry:ServiceName"] = "TestService",
+            ["Telemetry:ActivitySourceName"] = "TestActivity",
+            ["Telemetry:MeterName"] = "TestMeter",
+            ["Telemetry:Trace:Type"] = "console",
+            ["Telemetry:Metrics:Type"] = "console",
+            ["Telemetry:Log:Type"] = "console"
+        });
+
+        // Act & Assert - should not throw
+        WebApplication? app = null;
+        Assert.DoesNotThrow(() =>
+        {
+            builder.AddSpydersoftTelemetry(typeof(ConfigurationFunctionsTests).Assembly, null);
+            app = builder.Build();
+        });
+        
+        if (app != null)
+        {
+            await app.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task AddSpydersoftTelemetry_WithDisabledTelemetry_ShouldNotInvokeCallbacks()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Telemetry:Enabled"] = "false",
+            ["Telemetry:ServiceName"] = "TestService"
+        });
+
+        var configFunctions = new ConfigurationFunctions
+        {
+            TraceConfiguration = (traceBuilder) => _traceConfigCalled = true,
+            MetricsConfiguration = (metricsBuilder) => _metricsConfigCalled = true,
+            LogConfiguration = (logBuilder) => _logConfigCalled = true
+        };
+
+        // Act
+        builder.AddSpydersoftTelemetry(typeof(ConfigurationFunctionsTests).Assembly, configFunctions);
+        var app = builder.Build();
+
+        // Assert
+        Assert.That(_traceConfigCalled, Is.False, "TraceConfiguration should not be called when telemetry is disabled");
+        Assert.That(_metricsConfigCalled, Is.False, "MetricsConfiguration should not be called when telemetry is disabled");
+        Assert.That(_logConfigCalled, Is.False, "LogConfiguration should not be called when telemetry is disabled");
+
+        await app.DisposeAsync();
+    }
+
+    [Test]
+    public void ConfigurationFunctions_Properties_ShouldBeSettable()
+    {
+        // Arrange & Act
+        var configFunctions = new ConfigurationFunctions
+        {
+            TraceConfiguration = (builder) => { },
+            MetricsConfiguration = (builder) => { },
+            LogConfiguration = (builder) => { },
+            AspNetFilterFunction = (context) => true,
+            AspNetRequestEnrichAction = (activity, request) => { },
+            AspNetResponseEnrichAction = (activity, response) => { },
+            AspNetExceptionEnrichAction = (activity, exception) => { }
+        };
+
+        // Assert
+        Assert.That(configFunctions.TraceConfiguration, Is.Not.Null);
+        Assert.That(configFunctions.MetricsConfiguration, Is.Not.Null);
+        Assert.That(configFunctions.LogConfiguration, Is.Not.Null);
+        Assert.That(configFunctions.AspNetFilterFunction, Is.Not.Null);
+        Assert.That(configFunctions.AspNetRequestEnrichAction, Is.Not.Null);
+        Assert.That(configFunctions.AspNetResponseEnrichAction, Is.Not.Null);
+        Assert.That(configFunctions.AspNetExceptionEnrichAction, Is.Not.Null);
+    }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ConfigurationFunctionsTests.cs
@@ -29,7 +29,7 @@ public class ConfigurationFunctionsTests
     {
         // Arrange
         var builder = WebApplication.CreateBuilder();
-        
+
         // Add minimal telemetry configuration
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -65,11 +65,14 @@ public class ConfigurationFunctionsTests
         builder.AddSpydersoftTelemetry(typeof(ConfigurationFunctionsTests).Assembly, configFunctions);
         var app = builder.Build();
 
-        // Assert
-        Assert.That(_traceConfigCalled, Is.True, "TraceConfiguration should be called");
-        Assert.That(_metricsConfigCalled, Is.True, "MetricsConfiguration should be called");
-        Assert.That(_logConfigCalled, Is.True, "LogConfiguration should be called");
-
+        using (Assert.EnterMultipleScope())
+        {
+            // Assert - callbacks should have been called during Build()
+            // Assert
+            Assert.That(_traceConfigCalled, Is.True, "TraceConfiguration should be called");
+            Assert.That(_metricsConfigCalled, Is.True, "MetricsConfiguration should be called");
+            Assert.That(_logConfigCalled, Is.True, "LogConfiguration should be called");
+        }
         await app.DisposeAsync();
     }
 
@@ -78,7 +81,7 @@ public class ConfigurationFunctionsTests
     {
         // Arrange
         var builder = WebApplication.CreateBuilder();
-        
+
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Telemetry:Enabled"] = "true",
@@ -97,7 +100,7 @@ public class ConfigurationFunctionsTests
             builder.AddSpydersoftTelemetry(typeof(ConfigurationFunctionsTests).Assembly, null);
             app = builder.Build();
         });
-        
+
         if (app != null)
         {
             await app.DisposeAsync();
@@ -109,7 +112,7 @@ public class ConfigurationFunctionsTests
     {
         // Arrange
         var builder = WebApplication.CreateBuilder();
-        
+
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Telemetry:Enabled"] = "false",
@@ -127,11 +130,13 @@ public class ConfigurationFunctionsTests
         builder.AddSpydersoftTelemetry(typeof(ConfigurationFunctionsTests).Assembly, configFunctions);
         var app = builder.Build();
 
-        // Assert
-        Assert.That(_traceConfigCalled, Is.False, "TraceConfiguration should not be called when telemetry is disabled");
-        Assert.That(_metricsConfigCalled, Is.False, "MetricsConfiguration should not be called when telemetry is disabled");
-        Assert.That(_logConfigCalled, Is.False, "LogConfiguration should not be called when telemetry is disabled");
-
+        using (Assert.EnterMultipleScope())
+        {
+            // Assert
+            Assert.That(_traceConfigCalled, Is.False, "TraceConfiguration should not be called when telemetry is disabled");
+            Assert.That(_metricsConfigCalled, Is.False, "MetricsConfiguration should not be called when telemetry is disabled");
+            Assert.That(_logConfigCalled, Is.False, "LogConfiguration should not be called when telemetry is disabled");
+        }
         await app.DisposeAsync();
     }
 
@@ -150,13 +155,16 @@ public class ConfigurationFunctionsTests
             AspNetExceptionEnrichAction = (activity, exception) => { }
         };
 
-        // Assert
-        Assert.That(configFunctions.TraceConfiguration, Is.Not.Null);
-        Assert.That(configFunctions.MetricsConfiguration, Is.Not.Null);
-        Assert.That(configFunctions.LogConfiguration, Is.Not.Null);
-        Assert.That(configFunctions.AspNetFilterFunction, Is.Not.Null);
-        Assert.That(configFunctions.AspNetRequestEnrichAction, Is.Not.Null);
-        Assert.That(configFunctions.AspNetResponseEnrichAction, Is.Not.Null);
-        Assert.That(configFunctions.AspNetExceptionEnrichAction, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            // Assert
+            Assert.That(configFunctions.TraceConfiguration, Is.Not.Null);
+            Assert.That(configFunctions.MetricsConfiguration, Is.Not.Null);
+            Assert.That(configFunctions.LogConfiguration, Is.Not.Null);
+            Assert.That(configFunctions.AspNetFilterFunction, Is.Not.Null);
+            Assert.That(configFunctions.AspNetRequestEnrichAction, Is.Not.Null);
+            Assert.That(configFunctions.AspNetResponseEnrichAction, Is.Not.Null);
+            Assert.That(configFunctions.AspNetExceptionEnrichAction, Is.Not.Null);
+        }
     }
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ExponentialHistogramConfigurationTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/ExponentialHistogramConfigurationTests.cs
@@ -1,0 +1,46 @@
+using Spydersoft.Platform.Hosting.HealthChecks;
+using Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
+using System.Net;
+using System.Text.Json;
+
+namespace Spydersoft.Platform.Hosting.UnitTests.ApiTests.Telemetry;
+
+public class ExponentialHistogramConfigurationTests : ApiTestBase
+{
+    public override string Environment => "ExponentialHistogram";
+
+    [Test]
+    public async Task Startup_ExponentialHistogramConfiguration_ShouldBeHealthy()
+    {
+        var result = await Client.GetAsync($"startup");
+
+        using var jsonResult = JsonDocument.Parse(await result.Content.ReadAsStringAsync());
+
+        var telemetryNode = jsonResult.RootElement;
+
+        var details = telemetryNode.Deserialize<HealthCheckResponseResult>(
+                JsonOptions
+        );
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(details, Is.Not.Null);
+            Assert.That(details?.Status, Is.EqualTo("Healthy"));
+            Assert.That(details?.Results, Contains.Key(nameof(TelemetryHealthCheck)));
+
+            var telemetryHealthCheckResults = details?.Results?[nameof(TelemetryHealthCheck)];
+            Assert.That(telemetryHealthCheckResults, Is.Not.Null);
+            Assert.That(telemetryHealthCheckResults?.Status, Is.EqualTo("Healthy"));
+            Assert.That(telemetryHealthCheckResults?.ResultData, Contains.Key("details"));
+
+            Assert.That(telemetryHealthCheckResults?.ResultData?["details"], Is.TypeOf<TelemetryHealthCheckDetails>());
+            var telemetryData = telemetryHealthCheckResults?.ResultData?["details"] as TelemetryHealthCheckDetails;
+
+            // Verify histogram aggregation is set to exponential
+            Assert.That(telemetryData?.Metrics.HistogramAggregation, Is.EqualTo("exponential"));
+            Assert.That(telemetryData?.Metrics.Type, Is.EqualTo("console"));
+            Assert.That(telemetryData?.Enabled, Is.True);
+        }
+    }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/OtlpHeadersConfigurationTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/OtlpHeadersConfigurationTests.cs
@@ -1,0 +1,71 @@
+using Spydersoft.Platform.Hosting.HealthChecks;
+using Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
+using System.Net;
+using System.Text.Json;
+
+namespace Spydersoft.Platform.Hosting.UnitTests.ApiTests.Telemetry;
+
+public class OtlpHeadersConfigurationTests : ApiTestBase
+{
+    public override string Environment => "OtlpHeaders";
+
+    [Test]
+    public async Task Startup_ConfigurationWithHeaders_ShouldBeHealthy()
+    {
+        var result = await Client.GetAsync($"startup");
+
+        using var jsonResult = JsonDocument.Parse(await result.Content.ReadAsStringAsync());
+
+        var telemetryNode = jsonResult.RootElement;
+
+        var details = telemetryNode.Deserialize<HealthCheckResponseResult>(
+                JsonOptions
+        );
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(details, Is.Not.Null);
+            Assert.That(details?.Status, Is.EqualTo("Healthy"));
+            Assert.That(details?.Results, Contains.Key(nameof(TelemetryHealthCheck)));
+
+            var telemetryHealthCheckResults = details?.Results?[nameof(TelemetryHealthCheck)];
+            Assert.That(telemetryHealthCheckResults, Is.Not.Null);
+            Assert.That(telemetryHealthCheckResults?.Status, Is.EqualTo("Healthy"));
+            Assert.That(telemetryHealthCheckResults?.ResultData, Contains.Key("details"));
+
+            Assert.That(telemetryHealthCheckResults?.ResultData?["details"], Is.TypeOf<TelemetryHealthCheckDetails>());
+            var telemetryData = telemetryHealthCheckResults?.ResultData?["details"] as TelemetryHealthCheckDetails;
+
+            // Verify basic configuration
+            Assert.That(telemetryData?.ActivitySourceName, Is.EqualTo("Platform.Test.Activity"));
+            Assert.That(telemetryData?.Enabled, Is.True);
+            Assert.That(telemetryData?.ServiceName, Is.EqualTo("Platform.Test"));
+
+            // Verify OTLP endpoints
+            Assert.That(telemetryData?.Log.Type, Is.EqualTo("otlp"));
+            Assert.That(telemetryData?.Log.Otlp.Endpoint, Is.EqualTo("http://log.localhost:12345"));
+            Assert.That(telemetryData?.Metrics.Type, Is.EqualTo("otlp"));
+            Assert.That(telemetryData?.Metrics.Otlp.Endpoint, Is.EqualTo("http://metrics.localhost:12345"));
+            Assert.That(telemetryData?.Trace.Type, Is.EqualTo("otlp"));
+            Assert.That(telemetryData?.Trace.Otlp.Endpoint, Is.EqualTo("http://trace.localhost:12345"));
+
+            // Verify headers are present
+            Assert.That(telemetryData?.Log.Otlp.Headers, Is.Not.Null);
+            Assert.That(telemetryData?.Log.Otlp.Headers, Contains.Key("Authorization"));
+            Assert.That(telemetryData?.Log.Otlp.Headers?["Authorization"], Is.EqualTo("Bearer log-token"));
+            Assert.That(telemetryData?.Log.Otlp.Headers, Contains.Key("X-Custom-Header"));
+            Assert.That(telemetryData?.Log.Otlp.Headers?["X-Custom-Header"], Is.EqualTo("custom-value"));
+
+            Assert.That(telemetryData?.Metrics.Otlp.Headers, Is.Not.Null);
+            Assert.That(telemetryData?.Metrics.Otlp.Headers, Contains.Key("Authorization"));
+            Assert.That(telemetryData?.Metrics.Otlp.Headers?["Authorization"], Is.EqualTo("Bearer metrics-token"));
+
+            Assert.That(telemetryData?.Trace.Otlp.Headers, Is.Not.Null);
+            Assert.That(telemetryData?.Trace.Otlp.Headers, Contains.Key("Authorization"));
+            Assert.That(telemetryData?.Trace.Otlp.Headers?["Authorization"], Is.EqualTo("Bearer trace-token"));
+            Assert.That(telemetryData?.Trace.Otlp.Headers, Contains.Key("X-Trace-Id"));
+            Assert.That(telemetryData?.Trace.Otlp.Headers?["X-Trace-Id"], Is.EqualTo("test-trace"));
+        }
+    }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/TelemetryDisabledConfigurationTests.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/ApiTests/Telemetry/TelemetryDisabledConfigurationTests.cs
@@ -1,0 +1,51 @@
+using Spydersoft.Platform.Hosting.HealthChecks;
+using Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
+using System.Net;
+using System.Text.Json;
+
+namespace Spydersoft.Platform.Hosting.UnitTests.ApiTests.Telemetry;
+
+public class TelemetryDisabledConfigurationTests : ApiTestBase
+{
+    public override string Environment => "TelemetryDisabled";
+
+    [Test]
+    public async Task Startup_TelemetryDisabled_ShouldShowDisabledStatus()
+    {
+        var result = await Client.GetAsync($"startup");
+
+        using var jsonResult = JsonDocument.Parse(await result.Content.ReadAsStringAsync());
+
+        var telemetryNode = jsonResult.RootElement;
+
+        var details = telemetryNode.Deserialize<HealthCheckResponseResult>(
+                JsonOptions
+        );
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(details, Is.Not.Null);
+            // When telemetry is disabled, overall status should be Degraded
+            Assert.That(details?.Status, Is.EqualTo("Degraded"));
+            Assert.That(details?.Results, Contains.Key(nameof(TelemetryHealthCheck)));
+
+            var telemetryHealthCheckResults = details?.Results?[nameof(TelemetryHealthCheck)];
+            Assert.That(telemetryHealthCheckResults, Is.Not.Null);
+            // Telemetry health check status should be Degraded when disabled
+            Assert.That(telemetryHealthCheckResults?.Status, Is.EqualTo("Degraded"));
+            Assert.That(telemetryHealthCheckResults?.ResultData, Contains.Key("details"));
+
+            Assert.That(telemetryHealthCheckResults?.ResultData?["details"], Is.TypeOf<TelemetryHealthCheckDetails>());
+            var telemetryData = telemetryHealthCheckResults?.ResultData?["details"] as TelemetryHealthCheckDetails;
+
+            // Verify telemetry is disabled
+            Assert.That(telemetryData?.Enabled, Is.False);
+            
+            // When disabled, the providers should not be present
+            Assert.That(telemetryData?.TracePresent, Is.False);
+            Assert.That(telemetryData?.MetricsPresent, Is.False);
+            Assert.That(telemetryData?.LogPresent, Is.False);
+        }
+    }
+}

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/coverlet.runsettings
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/coverlet.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>opencover,cobertura</Format>
-          <Exclude>[Spydersoft.Platform.Hosting.UnitTests]*</Exclude>
+          <Exclude>[Spydersoft.Platform.Hosting.UnitTests]*,[*.ApiTests]*</Exclude>
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
           <SingleHit>false</SingleHit>
           <UseSourceLink>false</UseSourceLink>

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckDataPropertyConvertor.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckDataPropertyConvertor.cs
@@ -2,8 +2,22 @@
 using System.Text.Json.Serialization;
 
 namespace Spydersoft.Platform.Hosting.HealthChecks;
+
+/// <summary>
+/// JSON converter for serializing and deserializing health check data dictionaries.
+/// Handles type information preservation for complex objects in health check results.
+/// </summary>
 public class HealthCheckDataPropertyConvertor : JsonConverter<IReadOnlyDictionary<string, object>>
 {
+    /// <summary>
+    /// Reads and converts JSON to a dictionary of health check data.
+    /// Deserializes objects using embedded type information.
+    /// </summary>
+    /// <param name="reader">The UTF-8 JSON reader.</param>
+    /// <param name="typeToConvert">The type to convert.</param>
+    /// <param name="options">JSON serializer options.</param>
+    /// <returns>A dictionary containing the deserialized health check data.</returns>
+    /// <exception cref="JsonException">Thrown when JSON is malformed or missing required fields.</exception>
     public override IReadOnlyDictionary<string, object>? Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
     {
         Dictionary<string, object> dictionary = [];
@@ -38,6 +52,13 @@ public class HealthCheckDataPropertyConvertor : JsonConverter<IReadOnlyDictionar
         throw new JsonException();
     }
 
+    /// <summary>
+    /// Writes a dictionary of health check data to JSON.
+    /// Embeds type information for each value to enable round-trip serialization.
+    /// </summary>
+    /// <param name="writer">The UTF-8 JSON writer.</param>
+    /// <param name="value">The dictionary to serialize.</param>
+    /// <param name="options">JSON serializer options.</param>
     public override void Write(Utf8JsonWriter writer, IReadOnlyDictionary<string, object> value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckResponseResult.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckResponseResult.cs
@@ -1,7 +1,32 @@
 ﻿namespace Spydersoft.Platform.Hosting.HealthChecks;
+
+/// <summary>
+/// Represents the aggregated response for all health checks.
+/// Contains overall status, total duration, and individual check results.
+/// </summary>
 public class HealthCheckResponseResult
 {
+    /// <summary>
+    /// Gets or sets the overall health status.
+    /// </summary>
+    /// <value>
+    /// The aggregated status across all health checks (e.g., "Healthy", "Degraded", "Unhealthy").
+    /// </value>
     public string Status { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the total duration for all health checks.
+    /// </summary>
+    /// <value>
+    /// A string representation of the total execution time.
+    /// </value>
     public string TotalDuration { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the individual health check results.
+    /// </summary>
+    /// <value>
+    /// A dictionary mapping health check names to their results.
+    /// </value>
     public Dictionary<string, HealthCheckResult>? Results { get; set; }
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckResult.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckResult.cs
@@ -2,12 +2,42 @@
 
 namespace Spydersoft.Platform.Hosting.HealthChecks;
 
+/// <summary>
+/// Represents the result of an individual health check.
+/// Contains status, description, duration, and additional data.
+/// </summary>
 public class HealthCheckResult
 {
+    /// <summary>
+    /// Gets or sets the health check description.
+    /// </summary>
+    /// <value>
+    /// A human-readable description of the health check.
+    /// </value>
     public string Description { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the health check status.
+    /// </summary>
+    /// <value>
+    /// The status (e.g., "Healthy", "Degraded", "Unhealthy").
+    /// </value>
     public string Status { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the duration of the health check execution.
+    /// </summary>
+    /// <value>
+    /// A string representation of the check duration.
+    /// </value>
     public string Duration { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets additional data associated with the health check.
+    /// </summary>
+    /// <value>
+    /// A dictionary of key-value pairs containing diagnostic information.
+    /// </value>
     [JsonConverter(typeof(HealthCheckDataPropertyConvertor))]
     public IReadOnlyDictionary<string, object> ResultData { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckWriter.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/HealthCheckWriter.cs
@@ -3,8 +3,19 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Text.Json;
 
 namespace Spydersoft.Platform.Hosting.HealthChecks;
+
+/// <summary>
+/// Provides JSON serialization for health check responses.
+/// </summary>
 static class HealthCheckWriter
 {
+    /// <summary>
+    /// Writes a health check report as JSON to the HTTP response.
+    /// Converts HealthReport entries into a structured JSON format.
+    /// </summary>
+    /// <param name="context">The HTTP context.</param>
+    /// <param name="healthReport">The health report to serialize.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
     public static Task WriteResponse(HttpContext context, HealthReport healthReport)
     {
         context.Response.ContentType = "application/json; charset=utf-8";

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/Telemetry/TelemetryHealthCheck.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/Telemetry/TelemetryHealthCheck.cs
@@ -5,12 +5,23 @@ using Spydersoft.Platform.Hosting.Options;
 
 namespace Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
 
+/// <summary>
+/// Health check that validates OpenTelemetry configuration and provider registration.
+/// Checks whether TracerProvider, MeterProvider, and LoggerProvider are properly registered.
+/// </summary>
 [HealthCheck(nameof(TelemetryHealthCheck), HealthStatus.Unhealthy, "startup")]
 public class TelemetryHealthCheck(IServiceProvider services, IOptions<TelemetryOptions> telemetryOptions) : IHealthCheck
 {
     private readonly TelemetryOptions _telemetryOptions = telemetryOptions.Value;
     private readonly IServiceProvider _services = services;
 
+    /// <summary>
+    /// Checks the health of the telemetry configuration.
+    /// Returns Healthy if all three providers (trace, metrics, logs) are present, otherwise Degraded.
+    /// </summary>
+    /// <param name="context">The health check context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the health check result.</returns>
     public Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
         var tracePresent = _services.GetService(typeof(OpenTelemetry.Trace.TracerProvider)) is OpenTelemetry.Trace.TracerProvider;

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/Telemetry/TelemetryHealthCheckDetails.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/HealthChecks/Telemetry/TelemetryHealthCheckDetails.cs
@@ -2,18 +2,89 @@
 
 namespace Spydersoft.Platform.Hosting.HealthChecks.Telemetry;
 
+/// <summary>
+/// Detailed information about telemetry configuration and provider status.
+/// Used in health check responses to provide diagnostic information.
+/// </summary>
 public class TelemetryHealthCheckDetails
 {
+    /// <summary>
+    /// Gets or sets the activity source name for tracing.
+    /// </summary>
+    /// <value>
+    /// The activity source name.
+    /// </value>
     public string ActivitySourceName { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether telemetry is enabled.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if telemetry is enabled; otherwise, <c>false</c>.
+    /// </value>
     public bool Enabled { get; set; } = false;
+    
+    /// <summary>
+    /// Gets or sets the log configuration options.
+    /// </summary>
+    /// <value>
+    /// The log options.
+    /// </value>
     public LogOptions Log { get; set; } = new LogOptions();
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the LoggerProvider is registered.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if LoggerProvider is present; otherwise, <c>false</c>.
+    /// </value>
     public bool LogPresent { get; set; } = false;
+    
+    /// <summary>
+    /// Gets or sets the meter name for metrics.
+    /// </summary>
+    /// <value>
+    /// The meter name.
+    /// </value>
     public string MeterName { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the metrics configuration options.
+    /// </summary>
+    /// <value>
+    /// The metrics options.
+    /// </value>
     public MetricsOptions Metrics { get; set; } = new MetricsOptions();
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the MeterProvider is registered.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if MeterProvider is present; otherwise, <c>false</c>.
+    /// </value>
     public bool MetricsPresent { get; set; } = false;
+    
+    /// <summary>
+    /// Gets or sets the OpenTelemetry service name.
+    /// </summary>
+    /// <value>
+    /// The service name.
+    /// </value>
     public string ServiceName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the trace configuration options.
+    /// </summary>
+    /// <value>
+    /// The trace options.
+    /// </value>
     public TraceOptions Trace { get; set; } = new TraceOptions();
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the TracerProvider is registered.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if TracerProvider is present; otherwise, <c>false</c>.
+    /// </value>
     public bool TracePresent { get; set; } = false;
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/AppHealthCheckOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/AppHealthCheckOptions.cs
@@ -1,24 +1,77 @@
 ﻿namespace Spydersoft.Platform.Hosting.Options;
+
+/// <summary>
+/// Configuration options for application health checks.
+/// Controls the behavior of Kubernetes-style health check endpoints (/readyz, /livez, /startup).
+/// </summary>
 public class AppHealthCheckOptions
 {
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
     public const string SectionName = "HealthCheck";
 
+    /// <summary>
+    /// Gets or sets a value indicating whether health checks are enabled.
+    /// When disabled, health check endpoints will not be configured.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if health checks are enabled; otherwise, <c>false</c>. Default is <c>true</c>.
+    /// </value>
     public bool Enabled { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets the comma-separated tags for readiness checks.
+    /// Health checks with matching tags will be included in the /readyz endpoint.
+    /// </summary>
+    /// <value>
+    /// The ready tags. Default is "ready".
+    /// </value>
     public string ReadyTags { get; set; } = "ready";
 
+    /// <summary>
+    /// Gets or sets the comma-separated tags for liveness checks.
+    /// Health checks with matching tags will be included in the /livez endpoint.
+    /// </summary>
+    /// <value>
+    /// The live tags. Default is "live".
+    /// </value>
     public string LiveTags { get; set; } = "live";
 
+    /// <summary>
+    /// Gets or sets the comma-separated tags for startup checks.
+    /// Health checks with matching tags will be included in the /startup endpoint.
+    /// </summary>
+    /// <value>
+    /// The startup tags. Default is "startup".
+    /// </value>
     public string StartupTags { get; set; } = "startup";
 
+    /// <summary>
+    /// Gets the ready tags as a list.
+    /// Splits the <see cref="ReadyTags"/> by comma and removes empty entries.
+    /// </summary>
+    /// <returns>A list of ready tag strings.</returns>
     public List<string> ReadyTagsList()
     {
         return [.. ReadyTags.Split(',', StringSplitOptions.RemoveEmptyEntries)];
     }
+    
+    /// <summary>
+    /// Gets the live tags as a list.
+    /// Splits the <see cref="LiveTags"/> by comma and removes empty entries.
+    /// </summary>
+    /// <returns>A list of live tag strings.</returns>
     public List<string> LiveTagsList()
     {
         return [.. LiveTags.Split(',', StringSplitOptions.RemoveEmptyEntries)];
     }
+    
+    /// <summary>
+    /// Gets the startup tags as a list.
+    /// Splits the <see cref="StartupTags"/> by comma and removes empty entries.
+    /// </summary>
+    /// <returns>A list of startup tag strings.</returns>
     public List<string> StartupTagsList()
 
     {

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/FusionCacheConfigOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/FusionCacheConfigOptions.cs
@@ -32,26 +32,92 @@ public class FusionCacheConfigOptions
     /// </value>
     public string CacheName { get; set; } = "FusionCache";
 
+    /// <summary>
+    /// Gets or sets the distributed cache type.
+    /// Determines which distributed cache provider to use for second-level caching.
+    /// </summary>
+    /// <value>
+    /// The distributed cache type. Default is <see cref="CacheType.None"/>.
+    /// </value>
     public CacheType DistributedCacheType { get; set; } = CacheType.None;
 
+    /// <summary>
+    /// Gets or sets the Redis configuration.
+    /// Only used when <see cref="DistributedCacheType"/> is set to <see cref="CacheType.Redis"/>.
+    /// </summary>
+    /// <value>
+    /// The Redis configuration.
+    /// </value>
     public RedisConfig Redis { get; set; } = new RedisConfig();
 
+    /// <summary>
+    /// Gets or sets the memory cache limit in megabytes.
+    /// Controls the maximum size of the in-memory L1 cache.
+    /// </summary>
+    /// <value>
+    /// The memory cache limit in MB. Default is 200.
+    /// </value>
     public long MemoryCacheLimitMB { get; set; } = 200;
 
+    /// <summary>
+    /// Gets or sets the default entry options for cached items.
+    /// These options apply to all cache entries unless overridden.
+    /// </summary>
+    /// <value>
+    /// The default entry options.
+    /// </value>
     public FusionCacheEntryOptions DefaultEntryOptions { get; set; } = new FusionCacheEntryOptions();
 
+    /// <summary>
+    /// Gets or sets the global FusionCache options.
+    /// Configures behavior such as serialization, events, and plugins.
+    /// </summary>
+    /// <value>
+    /// The cache options.
+    /// </value>
     public FusionCacheOptions CacheOptions { get; set; } = new FusionCacheOptions();
 }
 
+/// <summary>
+/// Specifies the type of distributed cache to use.
+/// </summary>
 public enum CacheType
 {
+    /// <summary>
+    /// No distributed cache. Only in-memory L1 caching is used.
+    /// </summary>
     None,
+    
+    /// <summary>
+    /// In-memory cache only.
+    /// </summary>
     Memory,
+    
+    /// <summary>
+    /// Redis-based distributed cache for L2 caching.
+    /// </summary>
     Redis
 }
 
+/// <summary>
+/// Configuration for Redis distributed cache connection.
+/// </summary>
 public sealed class RedisConfig
 {
+    /// <summary>
+    /// Gets or sets the Redis connection string.
+    /// </summary>
+    /// <value>
+    /// The connection string for connecting to Redis. Default is empty.
+    /// </value>
     public string ConnectionString { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the Redis instance name.
+    /// Used as a prefix for all cache keys to avoid collisions.
+    /// </summary>
+    /// <value>
+    /// The instance name. Default is "FusionCache".
+    /// </value>
     public string InstanceName { get; set; } = "FusionCache";
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/IdentityOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/IdentityOptions.cs
@@ -9,6 +9,13 @@ public class IdentityOptions
     /// </summary>
     public const string SectionName = "Identity";
 
+    /// <summary>
+    /// Gets or sets a value indicating whether identity/authentication is enabled.
+    /// When enabled, JWT Bearer authentication will be configured.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if identity is enabled; otherwise, <c>false</c>. Default is <c>false</c>.
+    /// </value>
     public bool Enabled { get; set; } = false;
 
     /// <summary>

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/LogOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/LogOptions.cs
@@ -1,7 +1,26 @@
 ﻿namespace Spydersoft.Platform.Hosting.Options;
+
+/// <summary>
+/// Configuration options for OpenTelemetry logging.
+/// Specifies the log exporter type and OTLP-specific settings.
+/// </summary>
 public class LogOptions
 {
+    /// <summary>
+    /// Gets or sets the log exporter type.
+    /// </summary>
+    /// <value>
+    /// The exporter type. Default is "console".
+    /// </value>
     public string Type { get; set; } = "console";
+    
+    /// <summary>
+    /// Gets or sets the OTLP exporter configuration.
+    /// Only used when <see cref="Type"/> is set to "otlp".
+    /// </summary>
+    /// <value>
+    /// The OTLP options.
+    /// </value>
     public OtlpOptions Otlp { get; set; } = new OtlpOptions();
 
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/MetricsOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/MetricsOptions.cs
@@ -1,8 +1,25 @@
 ﻿namespace Spydersoft.Platform.Hosting.Options;
+
+/// <summary>
+/// Configuration options for OpenTelemetry metrics.
+/// </summary>
 public class MetricsOptions
 {
+    /// <summary>
+    /// Gets or sets the histogram aggregation strategy.
+    /// Valid values are empty string (default explicit bounds) or "exponential" for exponential bucket histograms.
+    /// </summary>
     public string HistogramAggregation { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the OTLP configuration options for metrics export.
+    /// </summary>
     public OtlpOptions Otlp { get; set; } = new OtlpOptions();
+
+    /// <summary>
+    /// Gets or sets the metrics exporter type.
+    /// Valid values are "console" (default), "prometheus", or "otlp".
+    /// </summary>
     public string Type { get; set; } = "console";
 
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/OtlpOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/OtlpOptions.cs
@@ -1,9 +1,24 @@
 ﻿namespace Spydersoft.Platform.Hosting.Options;
 
+/// <summary>
+/// Configuration options for OpenTelemetry Protocol (OTLP) exporters.
+/// </summary>
 public class OtlpOptions
 {
+    /// <summary>
+    /// Gets or sets the OTLP endpoint URL.
+    /// </summary>
     public string? Endpoint { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the protocol to use for OTLP communication.
+    /// Valid values are "grpc" (default) or "http".
+    /// </summary>
     public string Protocol { get; set; } = "grpc";
 
+    /// <summary>
+    /// Gets or sets the headers to include with OTLP requests.
+    /// Useful for authentication tokens and custom metadata.
+    /// </summary>
     public Dictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/TelemetryOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/TelemetryOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace Spydersoft.Platform.Hosting.Options;
 
+/// <summary>
+/// Configuration options for OpenTelemetry telemetry (tracing, metrics, and logging).
+/// </summary>
 public class TelemetryOptions
 {
     /// <summary>
@@ -7,16 +10,44 @@ public class TelemetryOptions
     /// </summary>
     public const string SectionName = "Telemetry";
 
+    /// <summary>
+    /// Gets or sets the name of the OpenTelemetry ActivitySource for custom tracing.
+    /// </summary>
     public string ActivitySourceName { get; set; } = "Spydersoft.Otel.Activity";
+
+    /// <summary>
+    /// Gets the configuration section path for ASP.NET Core instrumentation options.
+    /// </summary>
     public string AspNetCoreInstrumentationSection { get; } = $"{SectionName}:AspNetCoreInstrumentation";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether OpenTelemetry telemetry is enabled.
+    /// </summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the name of the OpenTelemetry Meter for custom metrics.
+    /// </summary>
     public string MeterName { get; set; } = "Spydersoft.Otel.Meter";
+
+    /// <summary>
+    /// Gets or sets the service name used in OpenTelemetry resource attributes.
+    /// </summary>
     public string ServiceName { get; set; } = "spydersoft-otel-service";
 
+    /// <summary>
+    /// Gets or sets the tracing configuration options.
+    /// </summary>
     public TraceOptions Trace { get; set; } = new TraceOptions();
 
+    /// <summary>
+    /// Gets or sets the metrics configuration options.
+    /// </summary>
     public MetricsOptions Metrics { get; set; } = new MetricsOptions();
 
+    /// <summary>
+    /// Gets or sets the logging configuration options.
+    /// </summary>
     public LogOptions Log { get; set; } = new LogOptions();
 
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/TraceOptions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Options/TraceOptions.cs
@@ -1,10 +1,23 @@
 ﻿namespace Spydersoft.Platform.Hosting.Options;
 
+/// <summary>
+/// Configuration options for OpenTelemetry tracing.
+/// </summary>
 public class TraceOptions
 {
+    /// <summary>
+    /// Gets or sets the trace exporter type.
+    /// Valid values are "console" (default), "zipkin", or "otlp".
+    /// </summary>
     public string Type { get; set; } = "console";
 
+    /// <summary>
+    /// Gets or sets the OTLP configuration options for trace export.
+    /// </summary>
     public OtlpOptions Otlp { get; set; } = new OtlpOptions();
 
+    /// <summary>
+    /// Gets the configuration section path for Zipkin exporter options.
+    /// </summary>
     public string ZipkinConfigurationSection { get; } = $"{TelemetryOptions.SectionName}:Trace:Zipkin";
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.csproj
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageDescription>Spydersoft Platform Hosting extensions and classes</PackageDescription>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/DependencyInjectionExtensions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/DependencyInjectionExtensions.cs
@@ -10,11 +10,11 @@ namespace Spydersoft.Platform.Hosting.StartupExtensions;
 public static class DependencyInjectionExtensions
 {
     /// <summary>
-    /// Adds the decorated services.
+    /// Adds services decorated with <see cref="DependencyInjectionAttribute"/> to the service collection.
+    /// Automatically discovers and registers services across all loaded assemblies.
     /// </summary>
-    /// <param name="services">The services.</param>
-    /// <param name="serviceAssembly">The service assembly.</param>
-    /// <returns>IServiceCollection.</returns>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddSpydersoftDecoratedServices(this IServiceCollection services)
     {
         var rankedList = new List<Tuple<DependencyInjectionAttribute, Type>>();

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/FusionCacheExtensions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/FusionCacheExtensions.cs
@@ -13,13 +13,19 @@ using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
 
 namespace Spydersoft.Platform.Hosting.StartupExtensions;
 
+/// <summary>
+/// Extension methods for configuring FusionCache in ASP.NET Core applications.
+/// </summary>
 public static class FusionCacheExtensions
 {
     /// <summary>
-    /// Adds the aspire fusion cache.
+    /// Adds and configures FusionCache to the application.
+    /// Configures multi-layer caching with optional Redis distributed cache and backplane.
     /// </summary>
-    /// <param name="builder">The builder.</param>
-    /// <returns>WebApplicationBuilder.</returns>
+    /// <param name="builder">The web application builder.</param>
+    /// <param name="additionalConfiguration">Optional action to modify cache configuration options.</param>
+    /// <param name="additionalBuilder">Optional action to customize the FusionCache builder.</param>
+    /// <returns>The web application builder for chaining.</returns>
     public static WebApplicationBuilder AddSpydersoftFusionCache(this WebApplicationBuilder builder, Action<FusionCacheConfigOptions>? additionalConfiguration = null, Action<IFusionCacheBuilder>? additionalBuilder = null)
     {
         var cacheOptions = new FusionCacheConfigOptions();
@@ -33,11 +39,13 @@ public static class FusionCacheExtensions
     }
 
     /// <summary>
-    /// Configures the fusion cache.
+    /// Configures FusionCache services with the specified options.
+    /// Sets up memory cache, distributed cache (if enabled), and serialization.
     /// </summary>
-    /// <param name="services">The services.</param>
-    /// <param name="options">The options.</param>
-    /// <returns>IServiceCollection.</returns>
+    /// <param name="services">The service collection.</param>
+    /// <param name="options">The FusionCache configuration options.</param>
+    /// <param name="additionalBuilder">Optional action to customize the FusionCache builder.</param>
+    /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection ConfigureFusionCache(this IServiceCollection services, FusionCacheConfigOptions options, Action<IFusionCacheBuilder>? additionalBuilder = null)
     {
         if (!options.Enabled)

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/HealthCheckExtensions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/HealthCheckExtensions.cs
@@ -10,8 +10,19 @@ using Spydersoft.Platform.Hosting.Options;
 using System.Reflection;
 
 namespace Spydersoft.Platform.Hosting.StartupExtensions;
+
+/// <summary>
+/// Extension methods for configuring health checks in ASP.NET Core applications.
+/// </summary>
 public static class HealthCheckExtensions
 {
+    /// <summary>
+    /// Adds Spydersoft health checks to the application.
+    /// Automatically discovers and registers all health checks decorated with <see cref="HealthCheckAttribute"/>.
+    /// </summary>
+    /// <param name="appBuilder">The web application builder.</param>
+    /// <returns>The health check configuration options.</returns>
+    /// <exception cref="ConfigurationException">Thrown when required reflection methods cannot be found.</exception>
     public static AppHealthCheckOptions AddSpydersoftHealthChecks(this WebApplicationBuilder appBuilder)
     {
         var healthCheckOptions = new AppHealthCheckOptions();
@@ -47,6 +58,13 @@ public static class HealthCheckExtensions
         return healthCheckOptions;
     }
 
+    /// <summary>
+    /// Configures health check endpoints for Kubernetes-style probes.
+    /// Creates /readyz, /livez, /startup, and /configuration endpoints.
+    /// </summary>
+    /// <param name="appBuilder">The application builder.</param>
+    /// <param name="options">The health check configuration options.</param>
+    /// <returns>The application builder for chaining.</returns>
     public static IApplicationBuilder UseSpydersoftHealthChecks(this IApplicationBuilder appBuilder, AppHealthCheckOptions options)
     {
         if (!options.Enabled)

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/IdentityExtensions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/IdentityExtensions.cs
@@ -6,8 +6,18 @@ using Spydersoft.Platform.Hosting.Options;
 using Spydersoft.Platform.Hosting.StartupExtensions;
 
 namespace Spydersoft.Platform.Hosting.StartupExtensions;
+
+/// <summary>
+/// Extension methods for configuring JWT Bearer authentication and authorization.
+/// </summary>
 public static class IdentityExtensions
 {
+    /// <summary>
+    /// Adds JWT Bearer authentication to the application based on configuration.
+    /// Configures authentication and authorization services when identity is enabled.
+    /// </summary>
+    /// <param name="appBuilder">The web application builder.</param>
+    /// <returns><c>true</c> if authentication was configured; otherwise, <c>false</c>.</returns>
     public static bool AddSpydersoftIdentity(this WebApplicationBuilder appBuilder)
     {
         var authInstalled = false;
@@ -45,6 +55,12 @@ public static class IdentityExtensions
         return authInstalled;
     }
 
+    /// <summary>
+    /// Adds authentication middleware to the application pipeline if authentication was configured.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <param name="authInstalled">Value indicating whether authentication is configured.</param>
+    /// <returns>The application builder for chaining.</returns>
     public static IApplicationBuilder UseAuthentication(this IApplicationBuilder app, bool authInstalled)
     {
         if (authInstalled)
@@ -54,6 +70,12 @@ public static class IdentityExtensions
         return app;
     }
 
+    /// <summary>
+    /// Adds authorization middleware to the application pipeline if authentication was configured.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <param name="authInstalled">Value indicating whether authentication is configured.</param>
+    /// <returns>The application builder for chaining.</returns>
     public static IApplicationBuilder UseAuthorization(this IApplicationBuilder app, bool authInstalled)
     {
         if (authInstalled)

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/OptionsExtensions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/OptionsExtensions.cs
@@ -6,8 +6,19 @@ using System.Reflection;
 
 namespace Spydersoft.Platform.Hosting.StartupExtensions;
 
+/// <summary>
+/// Extension methods for automatically configuring options classes.
+/// </summary>
 public static class OptionsExtensions
 {
+    /// <summary>
+    /// Automatically discovers and configures options classes decorated with <see cref="InjectOptionsAttribute"/>.
+    /// Binds configuration sections to options classes based on attribute metadata.
+    /// </summary>
+    /// <param name="appBuilder">The web application builder.</param>
+    /// <param name="tagsToInclude">Tags to filter which options to include. Empty tags match all.</param>
+    /// <param name="sectionPrefix">Optional prefix to prepend to configuration section names.</param>
+    /// <exception cref="ConfigurationException">Thrown when required reflection methods cannot be found.</exception>
     public static void AddSpydersoftOptions(this WebApplicationBuilder appBuilder, IEnumerable<string> tagsToInclude, string? sectionPrefix = null)
     {
         MethodInfo addCheckMethod = GetOptionsConfigureMethod();

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/TelemetryExtensions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/StartupExtensions/TelemetryExtensions.cs
@@ -18,6 +18,9 @@ using System.Reflection;
 
 namespace Spydersoft.Platform.Hosting.StartupExtensions;
 
+/// <summary>
+/// Extension methods for configuring OpenTelemetry and Serilog in ASP.NET Core applications.
+/// </summary>
 public static class TelemetryExtensions
 {
     #region Public Startup Extensions    
@@ -41,6 +44,13 @@ public static class TelemetryExtensions
         }, writeToProviders: writeToProviders);
     }
 
+    /// <summary>
+    /// Adds OpenTelemetry tracing, metrics, and logging to the application with advanced configuration options.
+    /// </summary>
+    /// <param name="appBuilder">The web application builder.</param>
+    /// <param name="startupAssembly">The assembly used to determine the service version.</param>
+    /// <param name="configurationFunctions">Optional configuration functions for customizing telemetry behavior.</param>
+    /// <returns>The web application builder for method chaining.</returns>
     public static WebApplicationBuilder AddSpydersoftTelemetry(this WebApplicationBuilder appBuilder,
         Assembly startupAssembly,
         ConfigurationFunctions? configurationFunctions)
@@ -72,6 +82,12 @@ public static class TelemetryExtensions
         return appBuilder;
     }
 
+    /// <summary>
+    /// Adds OpenTelemetry tracing, metrics, and logging to the application with default configuration.
+    /// </summary>
+    /// <param name="appBuilder">The web application builder.</param>
+    /// <param name="startupAssembly">The assembly used to determine the service version.</param>
+    /// <returns>The web application builder for method chaining.</returns>
     public static WebApplicationBuilder AddSpydersoftTelemetry(this WebApplicationBuilder appBuilder, Assembly startupAssembly)
     {
         return AddSpydersoftTelemetry(appBuilder, startupAssembly, null);

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Telemetry/ConfigurationFunctions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Telemetry/ConfigurationFunctions.cs
@@ -6,14 +6,63 @@ using OpenTelemetry.Trace;
 
 namespace Spydersoft.Platform.Hosting.Telemetry;
 
+/// <summary>
+/// Provides configuration functions for customizing OpenTelemetry behavior, including
+/// tracing, metrics, logging, and ASP.NET Core instrumentation enrichment.
+/// </summary>
 public class ConfigurationFunctions
 {
+    /// <summary>
+    /// Gets or sets an action to configure additional tracing options.
+    /// Use this to add custom sources, processors, or other trace-specific configuration.
+    /// </summary>
     public Action<TracerProviderBuilder>? TraceConfiguration { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to configure additional metrics options.
+    /// Use this to add custom meters, views, or other metrics-specific configuration.
+    /// </summary>
     public Action<MeterProviderBuilder>? MetricsConfiguration { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to configure additional logging options.
+    /// Use this to add custom log processors or other logging-specific configuration.
+    /// </summary>
     public Action<LoggerProviderBuilder>? LogConfiguration { get; set; }
 
+    /// <summary>
+    /// Gets or sets a filter function to determine which ASP.NET Core requests should be traced.
+    /// Return <c>false</c> to exclude a request from tracing (e.g., health check endpoints).
+    /// </summary>
+    /// <remarks>
+    /// This function is called for each incoming HTTP request before tracing begins.
+    /// </remarks>
     public Func<HttpContext, bool>? AspNetFilterFunction { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to enrich traces with custom data from the HTTP request.
+    /// Use this to add custom tags or attributes based on the incoming request.
+    /// </summary>
+    /// <remarks>
+    /// This action is called after the request is received but before the response is sent.
+    /// </remarks>
     public Action<Activity, HttpRequest>? AspNetRequestEnrichAction { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to enrich traces with custom data from the HTTP response.
+    /// Use this to add custom tags or attributes based on the outgoing response.
+    /// </summary>
+    /// <remarks>
+    /// This action is called after the response is generated.
+    /// </remarks>
     public Action<Activity, HttpResponse>? AspNetResponseEnrichAction { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to enrich traces with custom data when an exception occurs.
+    /// Use this to add custom tags or attributes based on exception details.
+    /// </summary>
+    /// <remarks>
+    /// This action is called when an unhandled exception occurs during request processing.
+    /// </remarks>
     public Action<Activity, Exception>? AspNetExceptionEnrichAction { get; set; }
 }

--- a/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Telemetry/ConfigurationFunctions.cs
+++ b/src/Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting/Telemetry/ConfigurationFunctions.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Spydersoft.Platform.Hosting.Telemetry;
+
+public class ConfigurationFunctions
+{
+    public Action<TracerProviderBuilder>? TraceConfiguration { get; set; }
+    public Action<MeterProviderBuilder>? MetricsConfiguration { get; set; }
+    public Action<LoggerProviderBuilder>? LogConfiguration { get; set; }
+
+    public Func<HttpContext, bool>? AspNetFilterFunction { get; set; }
+    public Action<Activity, HttpRequest>? AspNetRequestEnrichAction { get; set; }
+    public Action<Activity, HttpResponse>? AspNetResponseEnrichAction { get; set; }
+    public Action<Activity, Exception>? AspNetExceptionEnrichAction { get; set; }
+}

--- a/src/Spydersoft.Platform.Hosting/docs/CHANGELOG.md
+++ b/src/Spydersoft.Platform.Hosting/docs/CHANGELOG.md
@@ -19,11 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache test controller in ApiTests project for testing different cache scenarios
 - Unit tests for FusionCache configurations (L1, L2, Redis, disabled scenarios)
 - Test configuration files for various FusionCache setups
+- `ConfigurationFunctions` class for advanced OpenTelemetry customization
+- AspNetCore instrumentation enrichment support (filter, request, response, and exception enrichment)
+- `Telemetry:Enabled` configuration option to enable/disable telemetry
+- `Telemetry:Metrics:HistogramAggregation` configuration option for histogram aggregation strategy
+- OTLP Headers support for custom authentication and metadata
 
 ### Changed
 
 - Updated project dependencies to include FusionCache and Redis caching packages
 - Enhanced TelemetryExtensions with additional configuration options
+- Refactored `AddSpydersoftTelemetry` to use `ConfigurationFunctions` class instead of individual Action parameters
+- Updated OpenTelemetry packages to version 1.14.0
+- Updated Serilog.AspNetCore to version 10.0.0
+- Updated FusionCache packages to version 2.5.0
+- Updated Microsoft.Extensions packages to version 10.0.1
+- Updated test packages (Microsoft.NET.Test.Sdk to 18.0.1, NUnit.Analyzers to 4.11.2, NUnit3TestAdapter to 6.0.1)
 
 ### Removed
 

--- a/src/Spydersoft.Platform/Spydersoft.Platform.UnitTests/coverlet.runsettings
+++ b/src/Spydersoft.Platform/Spydersoft.Platform.UnitTests/coverlet.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>opencover,cobertura</Format>
-          <Exclude>[Spydersoft.Platform.UnitTests]*</Exclude>
+          <Exclude>[Spydersoft.Platform.UnitTests]*,[*.ApiTests]*</Exclude>
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
           <SingleHit>false</SingleHit>
           <UseSourceLink>false</UseSourceLink>

--- a/src/Spydersoft.Platform/Spydersoft.Platform/Attributes/DependencyInjectionAttribute.cs
+++ b/src/Spydersoft.Platform/Spydersoft.Platform/Attributes/DependencyInjectionAttribute.cs
@@ -3,16 +3,19 @@ using System;
 namespace Spydersoft.Platform.Attributes;
 
 /// <summary>
-/// Class DependencyInjectionAttribute.
-/// Implements the <see cref="Attribute" />
+/// Attribute for marking classes to be automatically registered in the dependency injection container.
+/// Classes decorated with this attribute will be discovered and registered at application startup.
 /// </summary>
-/// <param name="ServiceInterface">The service interface.</param>
-/// <param name="ServiceLifetime">The service lifetime.</param>
-/// <param name="rank">The rank.</param>
 /// <seealso cref="Attribute" />
 [AttributeUsage(AttributeTargets.Class)]
 public class DependencyInjectionAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DependencyInjectionAttribute"/> class.
+    /// </summary>
+    /// <param name="serviceInterface">The service interface type to register.</param>
+    /// <param name="serviceLifetime">The service lifetime (Transient, Scoped, or Singleton). Default is Transient.</param>
+    /// <param name="rank">The registration rank for ordering multiple implementations. Default is 0.</param>
     public DependencyInjectionAttribute(Type serviceInterface, LifetimeOfService serviceLifetime = LifetimeOfService.Transient, int rank = 0)
     {
         ServiceInterface = serviceInterface;

--- a/src/Spydersoft.Platform/Spydersoft.Platform/Attributes/HealthCheckAttribute.cs
+++ b/src/Spydersoft.Platform/Spydersoft.Platform/Attributes/HealthCheckAttribute.cs
@@ -3,9 +3,19 @@ using System;
 
 namespace Spydersoft.Platform.Attributes;
 
+/// <summary>
+/// Attribute for marking health check classes to be automatically discovered and registered.
+/// Classes decorated with this attribute will be added to the health check pipeline at application startup.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class HealthCheckAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HealthCheckAttribute"/> class.
+    /// </summary>
+    /// <param name="name">The name of the health check.</param>
+    /// <param name="failureStatus">The health status to report when the check fails.</param>
+    /// <param name="tags">Comma-separated tags for categorizing the health check (e.g., "ready", "live", "startup").</param>
     public HealthCheckAttribute(string name, HealthStatus failureStatus, string tags = "")
     {
         Name = name;
@@ -13,11 +23,36 @@ public class HealthCheckAttribute : Attribute
         RawTags = tags;
         Tags = tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
     }
+    
+    /// <summary>
+    /// Gets the name of the health check.
+    /// </summary>
+    /// <value>
+    /// The health check name.
+    /// </value>
     public string Name { get; }
 
+    /// <summary>
+    /// Gets the health status to report when the check fails.
+    /// </summary>
+    /// <value>
+    /// The failure status (e.g., Unhealthy, Degraded).
+    /// </value>
     public HealthStatus? FailureStatus { get; }
 
+    /// <summary>
+    /// Gets the raw comma-separated tags string.
+    /// </summary>
+    /// <value>
+    /// The raw tags string.
+    /// </value>
     public string RawTags { get; }
 
+    /// <summary>
+    /// Gets the parsed array of tags.
+    /// </summary>
+    /// <value>
+    /// An array of tag strings.
+    /// </value>
     public string[] Tags { get; }
 }

--- a/src/Spydersoft.Platform/Spydersoft.Platform/Attributes/InjectOptionsAttribute.cs
+++ b/src/Spydersoft.Platform/Spydersoft.Platform/Attributes/InjectOptionsAttribute.cs
@@ -2,18 +2,46 @@
 
 namespace Spydersoft.Platform.Attributes;
 
+/// <summary>
+/// Attribute for marking options classes to be automatically configured from application settings.
+/// Classes decorated with this attribute will be bound to the specified configuration section at startup.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class InjectOptionsAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InjectOptionsAttribute"/> class.
+    /// </summary>
+    /// <param name="sectionName">The configuration section name to bind to this options class.</param>
+    /// <param name="tags">Optional comma-separated tags for filtering which options to include.</param>
     public InjectOptionsAttribute(string sectionName, string tags = "")
     {
         SectionName = sectionName;
         RawTags = tags;
         Tags = tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
     }
+    
+    /// <summary>
+    /// Gets the configuration section name.
+    /// </summary>
+    /// <value>
+    /// The section name in the configuration file.
+    /// </value>
     public string SectionName { get; }
 
+    /// <summary>
+    /// Gets the raw comma-separated tags string.
+    /// </summary>
+    /// <value>
+    /// The raw tags string.
+    /// </value>
     public string RawTags { get; }
 
+    /// <summary>
+    /// Gets the parsed array of tags.
+    /// </summary>
+    /// <value>
+    /// An array of tag strings for filtering.
+    /// </value>
     public string[] Tags { get; }
 }

--- a/src/Spydersoft.Platform/Spydersoft.Platform/Exceptions/ConfigurationException.cs
+++ b/src/Spydersoft.Platform/Spydersoft.Platform/Exceptions/ConfigurationException.cs
@@ -2,8 +2,16 @@
 
 namespace Spydersoft.Platform.Exceptions;
 
+/// <summary>
+/// Exception thrown when there is a configuration error in the application.
+/// This exception indicates issues with application settings, missing configuration, or invalid configuration values.
+/// </summary>
 public class ConfigurationException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the configuration error.</param>
     public ConfigurationException(string message) : base(message)
     {
     }

--- a/src/Spydersoft.Platform/Spydersoft.Platform/Spydersoft.Platform.csproj
+++ b/src/Spydersoft.Platform/Spydersoft.Platform/Spydersoft.Platform.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageDescription>Spydersoft Platform Hosting extensions and classes</PackageDescription>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request introduces enhanced support for telemetry configuration functions in the API test project, along with updates to dependencies and new configuration files for more flexible telemetry testing. The main focus is on enabling and tracking the execution of custom telemetry configuration functions, and providing endpoints and tests to verify their behavior.

**Telemetry configuration and tracking enhancements:**

* Added a singleton tracker class (`TestConfigurationFunctionTracker`) and a data model (`TestConfigurationFunctionTrackerData`) to record the execution counts of various telemetry configuration functions. [[1]](diffhunk://#diff-948877862d5e1486c41c9bd588506425d944e73edc32dabd2398b737210a2b4eR1-R30) [[2]](diffhunk://#diff-5d6f4293b0166ba5eadaa54a3261ccc156928b56fd592bece9005d1a473cd3a9R1-R12)
* Modified the startup logic in `Program.cs` to conditionally register custom telemetry configuration functions based on the `IncludeTelemetryConfigFunctions` setting, incrementing tracker counters for each function call.
* Added a new API controller (`TelemetryFunctionsAccessController`) that exposes the tracker data for external verification.

**Testing and verification:**

* Added unit tests (`ConfigurationFunctionsExecutionTests`) to verify that telemetry configuration functions are executed as expected and that their execution is properly tracked and exposed via the API.

**Configuration and dependency updates:**

* Added multiple new configuration files for testing different telemetry scenarios, such as advanced config, disabled telemetry, OTLP headers, exponential histograms, and configuration functions. [[1]](diffhunk://#diff-4d9e43d3d7734e868c2ce93cba8e7390ad9105574ceb8b4c07621b18cf0c81ccR1-R29) [[2]](diffhunk://#diff-f2f81e1d2a554716c4e98b339eed0a93ee222bb71ba9b1fb041545d71435268cR1-R28) [[3]](diffhunk://#diff-3562277866463c87f765a69959268740fe4aacbc9a0e7e8835597bb3129e8749R1-R22) [[4]](diffhunk://#diff-7fcab62ad60eb4f0983fa60a2889f310dc0767f20292b6e6d6ebfe404a7f5770R1-R49) [[5]](diffhunk://#diff-ce99d0f574623d4558d1d9da82a8f7e857ca2766542b67f2d0f3babbcd909420R1-R19)
* Updated package versions in `Directory.Packages.props` to the latest stable releases for Microsoft, OpenTelemetry, Serilog, FusionCache, and test-related packages.

**Minor refactoring:**

* Simplified the constructor of `CacheTestController` by removing an unused options parameter.