### PR TITLE
Common Messaging Library

### DIFF
--- a/.devops/pipeline-main.yml
+++ b/.devops/pipeline-main.yml
@@ -25,10 +25,11 @@ extends:
   parameters:
     projectsToBuild: |
       src/**/*.csproj
-    projectsToPack: "**/*.csproj;!**/*.UnitTests.csproj;!**/*.ApiTests.csproj"
+    projectsToPack: "**/*.csproj;!**/*.UnitTests.csproj;!**/*.ApiTests.csproj;!**/*.IntegrationTests.csproj"
     executeTests: true
     testProjects: |
       src/**/*.UnitTests.csproj
+      src/**/*.IntegrationTests.csproj
     externalPublishUrl: $(nuget-feed-url)
     externalPublishApiKey: $(nuget-feed-api-key)
     # If it's a PR or a build from main (not a tag) then don't publish to Nuget
@@ -52,8 +53,8 @@ extends:
     sonarProjectName: Spydersoft.Platform
     sonarExtraProperties: |
       sonar.projectKey=spydersoft_platform
-      sonar.test.inclusions=**/*.UnitTests/**,**/*.ApiTests/**
-      sonar.coverage.exclusions=**/*.UnitTests/**,**/*.ApiTests/**
+      sonar.test.inclusions=**/*.UnitTests/**,**/*.ApiTests/**,**/*.IntegrationTests/**
+      sonar.coverage.exclusions=**/*.UnitTests/**,**/*.ApiTests/**,**/*.IntegrationTests/**
       sonar.scanner.scanAll=false
     
     

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repository contains libraries with common tasks for Spydersoft projects.
 ## Libraries
 
 - [Spydersoft.Platform](./src/Spydersoft.Platform/)
-- [Spydersoft.Platform.Hosting](./src/Spydersoft.Platform.Hosting//)
+- [Spydersoft.Platform.Hosting](./src/Spydersoft.Platform.Hosting/)
+- [Spydersoft.Messaging](./src/Spydersoft.Messaging/)
+- [Spydersoft.Messaging.RabbitMQ](./src/Spydersoft.Messaging.RabbitMQ/)
 
 ## Directory Structure
 

--- a/docs/messaging-spec.md
+++ b/docs/messaging-spec.md
@@ -25,8 +25,9 @@ src/
     docs/
       README.md
   Spydersoft.Messaging.RabbitMQ/
-    Spydersoft.Messaging.RabbitMQ/      ← RabbitMQ implementation
-    Spydersoft.Messaging.RabbitMQ.IntegrationTests/
+    Spydersoft.Messaging.RabbitMQ/                    ← RabbitMQ implementation
+    Spydersoft.Messaging.RabbitMQ.UnitTests/
+    Spydersoft.Messaging.RabbitMQ.IntegrationTests/   ← Testcontainers-based broker tests
     docs/
       README.md
 ```

--- a/docs/messaging-spec.md
+++ b/docs/messaging-spec.md
@@ -1,0 +1,420 @@
+# Spydersoft.Messaging — Specification
+
+## Overview
+
+Add a transport-agnostic messaging abstraction to the Spydersoft Platform, distributed as two NuGet packages:
+
+| Package | Purpose |
+|---|---|
+| `Spydersoft.Messaging` | Core interfaces and contracts. No transport dependency. |
+| `Spydersoft.Messaging.RabbitMQ` | RabbitMQ.Client implementation of the core interfaces. |
+
+The split follows the same pattern already used in `Spydersoft.Platform` / `Spydersoft.Platform.Hosting`: a transport-agnostic core that consumers depend on, and a concrete implementation that can be swapped (e.g., for Kafka) later by providing a new package without changing callers.
+
+---
+
+## Repository Location
+
+New solution folder inside the existing platform repo:
+
+```
+src/
+  Spydersoft.Messaging/
+    Spydersoft.Messaging/               ← core library
+    Spydersoft.Messaging.UnitTests/
+    docs/
+      README.md
+  Spydersoft.Messaging.RabbitMQ/
+    Spydersoft.Messaging.RabbitMQ/      ← RabbitMQ implementation
+    Spydersoft.Messaging.RabbitMQ.IntegrationTests/
+    docs/
+      README.md
+```
+
+---
+
+## Target Frameworks
+
+Both packages should multi-target to match the rest of the platform:
+
+```xml
+<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+```
+
+---
+
+## Package: `Spydersoft.Messaging`
+
+### Namespace root
+`Spydersoft.Messaging`
+
+### Core Types
+
+#### `MessageEnvelope<T>`
+
+Wraps a payload with routing and observability metadata. This is the over-the-wire type — both publisher and consumer deal in envelopes.
+
+```csharp
+namespace Spydersoft.Messaging;
+
+public sealed class MessageEnvelope<T>
+{
+    public required T Payload { get; init; }
+    public string MessageId { get; init; } = Guid.NewGuid().ToString();
+    public DateTimeOffset PublishedAt { get; init; } = DateTimeOffset.UtcNow;
+    public string? CorrelationId { get; init; }
+    public string? Source { get; init; }
+    public string? Topic { get; init; }
+}
+```
+
+#### `IMessagePublisher`
+
+```csharp
+namespace Spydersoft.Messaging;
+
+public interface IMessagePublisher
+{
+    /// <summary>
+    /// Publishes a message to the specified topic.
+    /// The message is wrapped in a MessageEnvelope by the implementation.
+    /// </summary>
+    Task PublishAsync<T>(string topic, T message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a pre-built envelope to the specified topic.
+    /// Use this overload when you need to control envelope metadata (e.g. CorrelationId).
+    /// </summary>
+    Task PublishAsync<T>(string topic, MessageEnvelope<T> envelope, CancellationToken cancellationToken = default);
+}
+```
+
+#### `IMessageHandler<T>`
+
+Implemented by consumers to process a specific message type.
+
+```csharp
+namespace Spydersoft.Messaging;
+
+public interface IMessageHandler<T>
+{
+    Task HandleAsync(MessageEnvelope<T> envelope, CancellationToken cancellationToken = default);
+}
+```
+
+### DI Registration
+
+Extension method on `IServiceCollection` (not `WebApplicationBuilder`, since this core package should work in non-web host scenarios like worker services):
+
+```csharp
+namespace Spydersoft.Messaging;
+
+public static class MessagingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers Spydersoft.Messaging core services.
+    /// Call this before adding a transport implementation (e.g. AddSpydersoftRabbitMq).
+    /// </summary>
+    public static IServiceCollection AddSpydersoftMessaging(this IServiceCollection services)
+    {
+        // Currently a no-op placeholder; provides a consistent registration entry point
+        // and a place to add cross-cutting concerns (e.g. middleware pipeline, metrics) later.
+        return services;
+    }
+}
+```
+
+### Notes
+
+- No transport packages referenced — `Spydersoft.Messaging` depends only on `Microsoft.Extensions.DependencyInjection.Abstractions`.
+- `MessageEnvelope<T>` is serialized as JSON over the wire; implementations are responsible for serialization. Use `System.Text.Json` as the default.
+
+---
+
+## Package: `Spydersoft.Messaging.RabbitMQ`
+
+### Namespace root
+`Spydersoft.Messaging.RabbitMQ`
+
+### NuGet Dependencies
+
+```xml
+<PackageReference Include="RabbitMQ.Client" />           <!-- Apache 2.0 -->
+<PackageReference Include="Spydersoft.Messaging" />
+<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+<PackageReference Include="Microsoft.Extensions.Options" />
+<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+```
+
+### Configuration
+
+#### `RabbitMqOptions`
+
+```csharp
+namespace Spydersoft.Messaging.RabbitMQ.Options;
+
+public class RabbitMqOptions
+{
+    public const string SectionName = "RabbitMq";
+
+    public string Host { get; set; } = "localhost";
+    public int Port { get; set; } = 5672;
+    public string VirtualHost { get; set; } = "/";
+    public string Username { get; set; } = "guest";
+    public string Password { get; set; } = "guest";
+
+    /// <summary>
+    /// Exchange to publish messages to. Defaults to a direct exchange.
+    /// </summary>
+    public string Exchange { get; set; } = "spydersoft.messaging";
+
+    /// <summary>
+    /// Exchange type: "direct", "topic", "fanout", "headers".
+    /// </summary>
+    public string ExchangeType { get; set; } = "topic";
+
+    /// <summary>
+    /// Whether the exchange should survive broker restarts.
+    /// </summary>
+    public bool DurableExchange { get; set; } = true;
+
+    /// <summary>
+    /// Whether published messages are persisted to disk.
+    /// </summary>
+    public bool PersistentMessages { get; set; } = true;
+}
+```
+
+appsettings.json example:
+```json
+{
+  "RabbitMq": {
+    "Host": "localhost",
+    "Port": 5672,
+    "Username": "guest",
+    "Password": "guest",
+    "Exchange": "spydersoft.messaging",
+    "ExchangeType": "topic"
+  }
+}
+```
+
+### `RabbitMqMessagePublisher`
+
+Implements `IMessagePublisher`. Registered as a **singleton**.
+
+Behaviour:
+- Creates a single `IConnection` on first use (lazy, thread-safe).
+- Opens a new `IChannel` per `PublishAsync` call (channels are not thread-safe in RabbitMQ.Client v7+).
+- Serializes the `MessageEnvelope<T>` to JSON using `System.Text.Json`.
+- Sets `BasicProperties.DeliveryMode` to persistent when `RabbitMqOptions.PersistentMessages` is true.
+- Uses the topic as the routing key.
+
+```csharp
+namespace Spydersoft.Messaging.RabbitMQ;
+
+public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposable
+{
+    // Constructor: IOptions<RabbitMqOptions>, ILogger<RabbitMqMessagePublisher>
+    // ...
+}
+```
+
+### Consumer Registration
+
+Rather than a single `IMessageConsumer` interface (which would require consumers to deal with deserialization and routing themselves), the RabbitMQ package uses a **typed registration** model. Callers register `IMessageHandler<T>` implementations with a topic binding; the package wires up a background service that routes inbound messages to the correct handler.
+
+#### `RabbitMqConsumerRegistration`
+
+Internal record holding the binding for one handler:
+
+```csharp
+internal sealed record RabbitMqConsumerRegistration(
+    string Topic,
+    string QueueName,
+    Type MessageType,
+    Type HandlerType
+);
+```
+
+#### `RabbitMqConsumerBackgroundService`
+
+A `BackgroundService` that:
+1. Creates one connection and one channel per registered queue on startup.
+2. Declares the queue and binds it to the exchange with the configured routing key/topic.
+3. Starts a basic consumer loop.
+4. Deserializes inbound messages to `MessageEnvelope<T>` using `System.Text.Json`.
+5. Resolves the appropriate `IMessageHandler<T>` from a scoped `IServiceProvider` (one scope per message).
+6. Calls `handler.HandleAsync(envelope, ct)`.
+7. Acks the message on success; nacks (without requeue) on unhandled exception, sending the message to the dead-letter exchange if configured.
+
+### DI Registration
+
+```csharp
+namespace Spydersoft.Messaging.RabbitMQ;
+
+public static class RabbitMqMessagingBuilderExtensions
+{
+    /// <summary>
+    /// Adds the RabbitMQ transport for Spydersoft.Messaging.
+    /// </summary>
+    public static ISpydersoftMessagingBuilder AddSpydersoftRabbitMq(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<RabbitMqOptions>(configuration.GetSection(RabbitMqOptions.SectionName));
+        services.AddSingleton<IMessagePublisher, RabbitMqMessagePublisher>();
+        services.AddHostedService<RabbitMqConsumerBackgroundService>();
+        return new SpydersoftMessagingBuilder(services);
+    }
+
+    /// <summary>
+    /// Overload accepting an action for inline configuration.
+    /// </summary>
+    public static ISpydersoftMessagingBuilder AddSpydersoftRabbitMq(
+        this IServiceCollection services,
+        Action<RabbitMqOptions> configure)
+    { ... }
+}
+```
+
+#### `ISpydersoftMessagingBuilder` / `SpydersoftMessagingBuilder`
+
+A builder returned from `AddSpydersoftRabbitMq` that allows fluent consumer registration:
+
+```csharp
+namespace Spydersoft.Messaging;
+
+public interface ISpydersoftMessagingBuilder
+{
+    IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Registers a typed message handler for the given topic.
+    /// A dedicated queue named <paramref name="queueName"/> is declared and bound to the topic.
+    /// </summary>
+    ISpydersoftMessagingBuilder AddConsumer<TMessage, THandler>(
+        string topic,
+        string queueName)
+        where THandler : class, IMessageHandler<TMessage>;
+}
+```
+
+Usage example:
+```csharp
+services
+    .AddSpydersoftMessaging()
+    .AddSpydersoftRabbitMq(configuration)
+    .AddConsumer<AuditEvent, AuditEventHandler>(
+        topic: "audit.events",
+        queueName: "pitstop.audit-processor");
+```
+
+`AddConsumer` should:
+- Register `THandler` as `IMessageHandler<TMessage>` (scoped lifetime).
+- Store a `RabbitMqConsumerRegistration` in the DI container (e.g. as `IEnumerable<RabbitMqConsumerRegistration>`) so `RabbitMqConsumerBackgroundService` can discover all bindings.
+
+---
+
+## How PitStop Uses These Packages
+
+This section is informational — it lives in PitStop, not the platform repo.
+
+### Audit.NET Data Provider
+
+In `Spydersoft.PitStop.Data`, implement a custom Audit.NET provider:
+
+```csharp
+public sealed class RabbitMqAuditDataProvider : AuditDataProvider
+{
+    // Constructor: IMessagePublisher
+    // Topic constant: "audit.events"
+
+    public override object InsertEvent(AuditEvent auditEvent)
+    {
+        // fire-and-forget with Task.Run or use a channel for backpressure
+        _publisher.PublishAsync("audit.events", auditEvent).GetAwaiter().GetResult();
+        return auditEvent.EventId ?? Guid.NewGuid().ToString();
+    }
+
+    public override async Task<object> InsertEventAsync(AuditEvent auditEvent, CancellationToken ct)
+    {
+        await _publisher.PublishAsync("audit.events", auditEvent, ct);
+        return auditEvent.EventId ?? Guid.NewGuid().ToString();
+    }
+}
+```
+
+Configure Audit.NET in `Program.cs`:
+```csharp
+Audit.Core.Configuration.Setup()
+    .UseCustomProvider(new RabbitMqAuditDataProvider(publisher));
+```
+
+### AuditProcessor Worker Service
+
+New project: `Spydersoft.PitStop.AuditProcessor` (.NET Worker Service).
+
+Implements `IMessageHandler<AuditEvent>`:
+```csharp
+public sealed class AuditEventHandler : IMessageHandler<AuditEvent>
+{
+    // Constructor: IMongoCollection<AuditEventDocument>, ILogger<...>
+
+    public async Task HandleAsync(MessageEnvelope<AuditEvent> envelope, CancellationToken ct)
+    {
+        var doc = Map(envelope);
+        await _collection.InsertOneAsync(doc, cancellationToken: ct);
+    }
+}
+```
+
+MongoDB document model:
+```csharp
+public sealed class AuditEventDocument
+{
+    [BsonId] public ObjectId Id { get; init; }
+    public string EventType { get; init; } = default!;
+    public string EntityType { get; init; } = default!;
+    public string EntityId { get; init; } = default!;
+    public string Action { get; init; } = default!;     // Insert / Update / Delete
+    public string? UserId { get; init; }
+    public DateTimeOffset OccurredAt { get; init; }
+    public BsonDocument? OldValues { get; init; }
+    public BsonDocument? NewValues { get; init; }
+    public string? CorrelationId { get; init; }
+}
+```
+
+---
+
+## Aspire AppHost Changes (PitStop)
+
+Add RabbitMQ and MongoDB as Aspire resources:
+
+```csharp
+var rabbitmq = builder.AddRabbitMQ("rabbitmq");
+var mongo = builder.AddMongoDB("mongo");
+
+builder.AddProject<Projects.Spydersoft_PitStop_Api>("api")
+    .WithReference(rabbitmq)
+    .WithReference(postgres);
+
+builder.AddProject<Projects.Spydersoft_PitStop_AuditProcessor>("audit-processor")
+    .WithReference(rabbitmq)
+    .WithReference(mongo);
+```
+
+Aspire packages needed in AppHost:
+- `Aspire.Hosting.RabbitMQ`
+- `Aspire.Hosting.MongoDB`
+
+---
+
+## Out of Scope (for now)
+
+- Dead-letter exchange / dead-letter queue configuration (noted but not implemented in v1).
+- Kafka transport (`Spydersoft.Messaging.Kafka` — future package).
+- Message schema registry / versioning.
+- Publisher confirms / outbox pattern (considered; deferred to future iteration).
+- Retry policies on the consumer (consider adding Polly later).

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -45,6 +45,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
 		<PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
 
 		<!-- Third Party -->
 		<PackageVersion Include="NeoSmart.Caching.Sqlite.AspNetCore" Version="9.0.1" />
@@ -55,5 +56,6 @@
 		<PackageVersion Include="NUnit" Version="4.5.1" />
 		<PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
 		<PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+		<PackageVersion Include="Testcontainers.RabbitMq" Version="4.11.0" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -37,6 +37,15 @@
 		<!-- Resilience -->
 		<PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
 
+		<!-- Messaging -->
+		<PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+
 		<!-- Third Party -->
 		<PackageVersion Include="NeoSmart.Caching.Sqlite.AspNetCore" Version="9.0.1" />
 

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/AckNackTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/AckNackTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ.IntegrationTests;
+
+[NonParallelizable]
+internal class AckNackTests
+{
+    private RabbitMqOptions _options = null!;
+    private string _queueName = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _options = TestHelpers.BrokerOptions("test.ack-nack." + Guid.NewGuid().ToString("N"));
+        _queueName = "test.queue." + Guid.NewGuid().ToString("N");
+        SuccessHandler.Reset();
+        FailingHandler.Reset();
+    }
+
+    [Test]
+    public async Task SuccessfulHandler_AcksMessage_QueueDrains()
+    {
+        using var host = TestHelpers.BuildConsumerHost(_options, b =>
+            b.AddConsumer<Marker, SuccessHandler>("ack.topic", _queueName));
+        await host.StartAsync();
+        await TestHelpers.WaitForQueueAsync(_options, _queueName, TimeSpan.FromSeconds(10));
+
+        await using var publisher = TestHelpers.BuildPublisher(_options);
+        await publisher.PublishAsync("ack.topic", new Marker());
+
+        await SuccessHandler.Completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var drained = await TestHelpers.WaitForAsync(
+            () => GetQueueMessageCount(_queueName) == 0,
+            TimeSpan.FromSeconds(5));
+
+        Assert.That(drained, Is.True, "queue should be empty after successful handler ack");
+
+        await host.StopAsync();
+    }
+
+    [Test]
+    public async Task HandlerThrows_NacksWithoutRequeue_NoRedelivery()
+    {
+        using var host = TestHelpers.BuildConsumerHost(_options, b =>
+            b.AddConsumer<Marker, FailingHandler>("nack.topic", _queueName));
+        await host.StartAsync();
+        await TestHelpers.WaitForQueueAsync(_options, _queueName, TimeSpan.FromSeconds(10));
+
+        await using var publisher = TestHelpers.BuildPublisher(_options);
+        await publisher.PublishAsync("nack.topic", new Marker());
+
+        await FailingHandler.FirstCall.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Give the broker time to potentially redeliver — it should not, because nack is requeue=false.
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(FailingHandler.CallCount, Is.EqualTo(1), "handler must not be called more than once");
+            Assert.That(GetQueueMessageCount(_queueName), Is.EqualTo(0u), "queue should be empty (nack discarded message)");
+        });
+
+        await host.StopAsync();
+    }
+
+    private uint GetQueueMessageCount(string queueName)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = _options.Host,
+            Port = _options.Port,
+            UserName = _options.Username,
+            Password = _options.Password,
+        };
+        using var conn = factory.CreateConnectionAsync().GetAwaiter().GetResult();
+        using var channel = conn.CreateChannelAsync().GetAwaiter().GetResult();
+        var declareOk = channel.QueueDeclarePassiveAsync(queueName).GetAwaiter().GetResult();
+        return declareOk.MessageCount;
+    }
+
+    public sealed class Marker { }
+
+    public sealed class SuccessHandler : IMessageHandler<Marker>
+    {
+        public static TaskCompletionSource Completion { get; private set; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static void Reset() =>
+            Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task HandleAsync(MessageEnvelope<Marker> envelope, CancellationToken cancellationToken = default)
+        {
+            Completion.TrySetResult();
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class FailingHandler : IMessageHandler<Marker>
+    {
+        private static int _callCount;
+        public static int CallCount => Volatile.Read(ref _callCount);
+        public static TaskCompletionSource FirstCall { get; private set; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static void Reset()
+        {
+            Interlocked.Exchange(ref _callCount, 0);
+            FirstCall = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public Task HandleAsync(MessageEnvelope<Marker> envelope, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _callCount);
+            FirstCall.TrySetResult();
+            throw new InvalidOperationException("intentional test failure");
+        }
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/AckNackTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/AckNackTests.cs
@@ -57,11 +57,11 @@ internal class AckNackTests
         // Give the broker time to potentially redeliver — it should not, because nack is requeue=false.
         await Task.Delay(TimeSpan.FromSeconds(2));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(FailingHandler.CallCount, Is.EqualTo(1), "handler must not be called more than once");
-            Assert.That(GetQueueMessageCount(_queueName), Is.EqualTo(0u), "queue should be empty (nack discarded message)");
-        });
+            Assert.That(GetQueueMessageCount(_queueName), Is.Zero, "queue should be empty (nack discarded message)");
+        }
 
         await host.StopAsync();
     }

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/BasicPropertiesWireFormatTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/BasicPropertiesWireFormatTests.cs
@@ -55,15 +55,14 @@ internal class BasicPropertiesWireFormatTests
 
         var ea = await captured.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ea.BasicProperties.ContentType, Is.EqualTo("application/json"));
             Assert.That(ea.BasicProperties.MessageId, Is.EqualTo(envelope.MessageId));
             Assert.That(ea.BasicProperties.CorrelationId, Is.EqualTo("trace-xyz"));
-            // body should still be JSON
             var body = Encoding.UTF8.GetString(ea.Body.Span);
             Assert.That(body, Does.Contain("\"hello\""));
-        });
+        }
     }
 
     [Test]

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/BasicPropertiesWireFormatTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/BasicPropertiesWireFormatTests.cs
@@ -1,0 +1,111 @@
+using System.Text;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ.IntegrationTests;
+
+[NonParallelizable]
+internal class BasicPropertiesWireFormatTests
+{
+    private RabbitMqOptions _options = null!;
+
+    [SetUp]
+    public void SetUp() =>
+        _options = TestHelpers.BrokerOptions("test.basic-properties." + Guid.NewGuid().ToString("N"));
+
+    [Test]
+    public async Task PublishedMessage_HasContentTypeMessageIdAndCorrelationId()
+    {
+        var queueName = "test.props." + Guid.NewGuid().ToString("N");
+        var topic = "props.topic";
+
+        // Set up a raw consumer that captures the BasicDeliverEventArgs (and therefore properties) directly.
+        var factory = new ConnectionFactory
+        {
+            HostName = _options.Host,
+            Port = _options.Port,
+            UserName = _options.Username,
+            Password = _options.Password,
+        };
+        await using var conn = await factory.CreateConnectionAsync();
+        await using var channel = await conn.CreateChannelAsync();
+
+        await channel.ExchangeDeclareAsync(_options.Exchange, _options.ExchangeType,
+            durable: false, autoDelete: false);
+        await channel.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await channel.QueueBindAsync(queueName, _options.Exchange, topic);
+
+        var captured = new TaskCompletionSource<BasicDeliverEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += (_, ea) =>
+        {
+            captured.TrySetResult(ea);
+            return Task.CompletedTask;
+        };
+        await channel.BasicConsumeAsync(queueName, autoAck: true, consumer: consumer);
+
+        await using var publisher = TestHelpers.BuildPublisher(_options);
+        var envelope = new MessageEnvelope<Payload>
+        {
+            Payload = new Payload { Value = "hello" },
+            CorrelationId = "trace-xyz",
+        };
+        await publisher.PublishAsync(topic, envelope);
+
+        var ea = await captured.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ea.BasicProperties.ContentType, Is.EqualTo("application/json"));
+            Assert.That(ea.BasicProperties.MessageId, Is.EqualTo(envelope.MessageId));
+            Assert.That(ea.BasicProperties.CorrelationId, Is.EqualTo("trace-xyz"));
+            // body should still be JSON
+            var body = Encoding.UTF8.GetString(ea.Body.Span);
+            Assert.That(body, Does.Contain("\"hello\""));
+        });
+    }
+
+    [Test]
+    public async Task PublishedMessage_OmitsCorrelationId_WhenEnvelopeHasNone()
+    {
+        var queueName = "test.props.no-corr." + Guid.NewGuid().ToString("N");
+        var topic = "props.no-corr";
+
+        var factory = new ConnectionFactory
+        {
+            HostName = _options.Host,
+            Port = _options.Port,
+            UserName = _options.Username,
+            Password = _options.Password,
+        };
+        await using var conn = await factory.CreateConnectionAsync();
+        await using var channel = await conn.CreateChannelAsync();
+
+        await channel.ExchangeDeclareAsync(_options.Exchange, _options.ExchangeType,
+            durable: false, autoDelete: false);
+        await channel.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await channel.QueueBindAsync(queueName, _options.Exchange, topic);
+
+        var captured = new TaskCompletionSource<BasicDeliverEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += (_, ea) =>
+        {
+            captured.TrySetResult(ea);
+            return Task.CompletedTask;
+        };
+        await channel.BasicConsumeAsync(queueName, autoAck: true, consumer: consumer);
+
+        await using var publisher = TestHelpers.BuildPublisher(_options);
+        await publisher.PublishAsync(topic, new Payload { Value = "no-corr" });
+
+        var ea = await captured.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.That(ea.BasicProperties.CorrelationId, Is.Null.Or.Empty);
+    }
+
+    public sealed class Payload
+    {
+        public string Value { get; init; } = string.Empty;
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/JsonSerializerOptionsTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/JsonSerializerOptionsTests.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ.IntegrationTests;
+
+[NonParallelizable]
+internal class JsonSerializerOptionsTests
+{
+    [Test]
+    public async Task CustomJsonSerializerOptions_AreUsedByPublisherAndConsumer_RoundTrip()
+    {
+        // SnakeCaseLower is naming policy that survives a real round-trip; the default Web policy is camelCase.
+        var customOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = false,
+        };
+
+        var options = TestHelpers.BrokerOptions(
+            "test.json-options." + Guid.NewGuid().ToString("N"),
+            o => o.JsonSerializerOptions = customOptions);
+
+        SnakeHandler.Reset();
+
+        var queueName = "test.snake." + Guid.NewGuid().ToString("N");
+        using var host = TestHelpers.BuildConsumerHost(options, b =>
+            b.AddConsumer<SnakeMessage, SnakeHandler>("snake.topic", queueName));
+        await host.StartAsync();
+        await TestHelpers.WaitForQueueAsync(options, queueName, TimeSpan.FromSeconds(10));
+
+        await using var publisher = TestHelpers.BuildPublisher(options);
+        await publisher.PublishAsync("snake.topic", new SnakeMessage { LongPropertyName = "round-trip-ok" });
+
+        var received = await SnakeHandler.Completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.That(received.Payload.LongPropertyName, Is.EqualTo("round-trip-ok"));
+
+        await host.StopAsync();
+    }
+
+    [Test]
+    public async Task CustomJsonSerializerOptions_AreReflectedOnTheWire()
+    {
+        var customOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        };
+
+        var options = TestHelpers.BrokerOptions(
+            "test.json-wire." + Guid.NewGuid().ToString("N"),
+            o => o.JsonSerializerOptions = customOptions);
+
+        var queueName = "test.snake-wire." + Guid.NewGuid().ToString("N");
+        var topic = "snake.wire";
+
+        var factory = new ConnectionFactory
+        {
+            HostName = options.Host,
+            Port = options.Port,
+            UserName = options.Username,
+            Password = options.Password,
+        };
+        await using var conn = await factory.CreateConnectionAsync();
+        await using var channel = await conn.CreateChannelAsync();
+
+        await channel.ExchangeDeclareAsync(options.Exchange, options.ExchangeType,
+            durable: false, autoDelete: false);
+        await channel.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await channel.QueueBindAsync(queueName, options.Exchange, topic);
+
+        var captured = new TaskCompletionSource<BasicDeliverEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += (_, ea) =>
+        {
+            captured.TrySetResult(ea);
+            return Task.CompletedTask;
+        };
+        await channel.BasicConsumeAsync(queueName, autoAck: true, consumer: consumer);
+
+        await using var publisher = TestHelpers.BuildPublisher(options);
+        await publisher.PublishAsync(topic, new SnakeMessage { LongPropertyName = "wire" });
+
+        var ea = await captured.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var body = Encoding.UTF8.GetString(ea.Body.Span);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(body, Does.Contain("long_property_name"), "expected snake_case property name from custom JSON options");
+            Assert.That(body, Does.Not.Contain("longPropertyName"));
+        });
+    }
+
+    public sealed class SnakeMessage
+    {
+        public string LongPropertyName { get; init; } = string.Empty;
+    }
+
+    public sealed class SnakeHandler : IMessageHandler<SnakeMessage>
+    {
+        public static TaskCompletionSource<MessageEnvelope<SnakeMessage>> Completion { get; private set; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static void Reset() =>
+            Completion = new TaskCompletionSource<MessageEnvelope<SnakeMessage>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task HandleAsync(MessageEnvelope<SnakeMessage> envelope, CancellationToken cancellationToken = default)
+        {
+            Completion.TrySetResult(envelope);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/JsonSerializerOptionsTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/JsonSerializerOptionsTests.cs
@@ -86,11 +86,11 @@ internal class JsonSerializerOptionsTests
         var ea = await captured.Task.WaitAsync(TimeSpan.FromSeconds(10));
         var body = Encoding.UTF8.GetString(ea.Body.Span);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(body, Does.Contain("long_property_name"), "expected snake_case property name from custom JSON options");
             Assert.That(body, Does.Not.Contain("longPropertyName"));
-        });
+        }
     }
 
     public sealed class SnakeMessage

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/PublishConsumeTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/PublishConsumeTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Hosting;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ.IntegrationTests;
+
+[NonParallelizable]
+internal class PublishConsumeTests
+{
+    private RabbitMqOptions _options = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _options = TestHelpers.BrokerOptions("test.publish-consume." + Guid.NewGuid().ToString("N"));
+        OrderHandler.Reset();
+    }
+
+    [Test]
+    public async Task PublishAsync_RoundTripsEnvelopeToConsumer()
+    {
+        var queueName = "test.orders." + Guid.NewGuid().ToString("N");
+        using var host = TestHelpers.BuildConsumerHost(_options, b =>
+            b.AddConsumer<OrderMessage, OrderHandler>("orders.created", queueName));
+        await host.StartAsync();
+        await TestHelpers.WaitForQueueAsync(_options, queueName, TimeSpan.FromSeconds(10));
+
+        await using var publisher = TestHelpers.BuildPublisher(_options);
+        var envelope = new MessageEnvelope<OrderMessage>
+        {
+            Payload = new OrderMessage { OrderId = "ORD-42", Amount = 99.95m },
+            CorrelationId = "corr-abc",
+        };
+
+        await publisher.PublishAsync("orders.created", envelope);
+
+        var received = await OrderHandler.Completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Multiple(() =>
+        {
+            Assert.That(received.Payload.OrderId, Is.EqualTo("ORD-42"));
+            Assert.That(received.Payload.Amount, Is.EqualTo(99.95m));
+            Assert.That(received.MessageId, Is.EqualTo(envelope.MessageId));
+            Assert.That(received.CorrelationId, Is.EqualTo("corr-abc"));
+        });
+
+        await host.StopAsync();
+    }
+
+    public sealed class OrderMessage
+    {
+        public string OrderId { get; init; } = string.Empty;
+        public decimal Amount { get; init; }
+    }
+
+    public sealed class OrderHandler : IMessageHandler<OrderMessage>
+    {
+        public static TaskCompletionSource<MessageEnvelope<OrderMessage>> Completion { get; private set; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static void Reset() =>
+            Completion = new TaskCompletionSource<MessageEnvelope<OrderMessage>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task HandleAsync(MessageEnvelope<OrderMessage> envelope, CancellationToken cancellationToken = default)
+        {
+            Completion.TrySetResult(envelope);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/PublishConsumeTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/PublishConsumeTests.cs
@@ -34,13 +34,13 @@ internal class PublishConsumeTests
         await publisher.PublishAsync("orders.created", envelope);
 
         var received = await OrderHandler.Completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(received.Payload.OrderId, Is.EqualTo("ORD-42"));
             Assert.That(received.Payload.Amount, Is.EqualTo(99.95m));
             Assert.That(received.MessageId, Is.EqualTo(envelope.MessageId));
             Assert.That(received.CorrelationId, Is.EqualTo("corr-abc"));
-        });
+        }
 
         await host.StopAsync();
     }

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/RabbitMqContainerFixture.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/RabbitMqContainerFixture.cs
@@ -1,0 +1,37 @@
+using Testcontainers.RabbitMq;
+
+namespace Spydersoft.Messaging.RabbitMQ.IntegrationTests;
+
+[SetUpFixture]
+public sealed class RabbitMqContainerFixture
+{
+    private const string TestUsername = "guest";
+    private const string TestPassword = "guest";
+
+    public static RabbitMqContainer Container { get; private set; } = null!;
+
+    public static string Host => Container.Hostname;
+    public static int Port => Container.GetMappedPublicPort(5672);
+    public static string Username => TestUsername;
+    public static string Password => TestPassword;
+
+    [OneTimeSetUp]
+    public async Task GlobalSetUp()
+    {
+        Container = new RabbitMqBuilder("rabbitmq:3.13-management")
+            .WithUsername(TestUsername)
+            .WithPassword(TestPassword)
+            .Build();
+
+        await Container.StartAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task GlobalTearDown()
+    {
+        if (Container is not null)
+        {
+            await Container.DisposeAsync();
+        }
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/Spydersoft.Messaging.RabbitMQ.IntegrationTests.csproj
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/Spydersoft.Messaging.RabbitMQ.IntegrationTests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<RunSettingsFilePath>$(MSBuildThisFileDirectory)\coverlet.runsettings</RunSettingsFilePath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NUnit" />
+		<PackageReference Include="NUnit.Analyzers">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="RabbitMQ.Client" />
+		<PackageReference Include="Testcontainers.RabbitMq" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Spydersoft.Messaging.RabbitMQ\Spydersoft.Messaging.RabbitMQ.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="NUnit.Framework" />
+	</ItemGroup>
+
+</Project>

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/TestHelpers.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/TestHelpers.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ.IntegrationTests;
+
+internal static class TestHelpers
+{
+    public static RabbitMqOptions BrokerOptions(string exchange, Action<RabbitMqOptions>? customize = null)
+    {
+        var options = new RabbitMqOptions
+        {
+            Host = RabbitMqContainerFixture.Host,
+            Port = RabbitMqContainerFixture.Port,
+            Username = RabbitMqContainerFixture.Username,
+            Password = RabbitMqContainerFixture.Password,
+            Exchange = exchange,
+            ExchangeType = "topic",
+            DurableExchange = false,
+            PersistentMessages = false,
+        };
+        customize?.Invoke(options);
+        return options;
+    }
+
+    public static RabbitMqMessagePublisher BuildPublisher(RabbitMqOptions options) =>
+        new(Microsoft.Extensions.Options.Options.Create(options),
+            LoggerFactory.Create(b => { }).CreateLogger<RabbitMqMessagePublisher>());
+
+    public static IHost BuildConsumerHost(
+        RabbitMqOptions options,
+        Action<ISpydersoftMessagingBuilder> registerConsumers)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+
+        var messagingBuilder = builder.Services.AddSpydersoftRabbitMq(opts =>
+        {
+            opts.Host = options.Host;
+            opts.Port = options.Port;
+            opts.VirtualHost = options.VirtualHost;
+            opts.Username = options.Username;
+            opts.Password = options.Password;
+            opts.Exchange = options.Exchange;
+            opts.ExchangeType = options.ExchangeType;
+            opts.DurableExchange = options.DurableExchange;
+            opts.PersistentMessages = options.PersistentMessages;
+            opts.JsonSerializerOptions = options.JsonSerializerOptions;
+        });
+
+        registerConsumers(messagingBuilder);
+
+        return builder.Build();
+    }
+
+    public static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return true;
+            }
+            await Task.Delay(50);
+        }
+        return condition();
+    }
+
+    /// <summary>
+    /// Waits for the named queue to exist on the broker. The consumer background service
+    /// declares queues asynchronously inside ExecuteAsync, which races with the test's
+    /// publish call — polling QueueDeclarePassive ensures the binding is in place before we publish.
+    /// </summary>
+    public static async Task WaitForQueueAsync(RabbitMqOptions options, string queueName, TimeSpan timeout)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = options.Host,
+            Port = options.Port,
+            UserName = options.Username,
+            Password = options.Password,
+        };
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            try
+            {
+                await using var conn = await factory.CreateConnectionAsync();
+                await using var channel = await conn.CreateChannelAsync();
+                await channel.QueueDeclarePassiveAsync(queueName);
+                return;
+            }
+            catch
+            {
+                await Task.Delay(100);
+            }
+        }
+        throw new TimeoutException($"Queue '{queueName}' was not declared within {timeout}.");
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/coverlet.runsettings
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/coverlet.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover,cobertura</Format>
+          <Exclude>[Spydersoft.Messaging.RabbitMQ.IntegrationTests]*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>false</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SkipAutoProps>false</SkipAutoProps>
+          <DeterministicReport>false</DeterministicReport>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/BuilderTests/AddConsumerTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/BuilderTests/AddConsumerTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.DependencyInjection;
+using Spydersoft.Messaging;
+using Spydersoft.Messaging.RabbitMQ;
+
+namespace Spydersoft.Messaging.RabbitMQ.UnitTests.BuilderTests;
+
+internal class AddConsumerTests
+{
+    private IServiceCollection _services = null!;
+    private ISpydersoftMessagingBuilder _builder = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _services = new ServiceCollection();
+        _builder = _services.AddSpydersoftRabbitMq(opts => opts.Host = "localhost");
+    }
+
+    [Test]
+    public void AddConsumer_RegistersHandlerAsScoped()
+    {
+        _builder.AddConsumer<TestMessage, TestMessageHandler>("test.topic", "test-queue");
+
+        var descriptor = _services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IMessageHandler<TestMessage>) &&
+            d.ImplementationType == typeof(TestMessageHandler));
+
+        Assert.That(descriptor, Is.Not.Null);
+        Assert.That(descriptor!.Lifetime, Is.EqualTo(ServiceLifetime.Scoped));
+    }
+
+    [Test]
+    public void AddConsumer_RegistersConsumerRegistrationWithCorrectValues()
+    {
+        _builder.AddConsumer<TestMessage, TestMessageHandler>("test.topic", "test-queue");
+
+        var provider = _services.BuildServiceProvider();
+        var registrations = provider.GetServices<RabbitMqConsumerRegistration>().ToList();
+
+        Assert.That(registrations, Has.Count.EqualTo(1));
+        Assert.That(registrations[0].Topic, Is.EqualTo("test.topic"));
+        Assert.That(registrations[0].QueueName, Is.EqualTo("test-queue"));
+        Assert.That(registrations[0].MessageType, Is.EqualTo(typeof(TestMessage)));
+        Assert.That(registrations[0].HandlerType, Is.EqualTo(typeof(TestMessageHandler)));
+    }
+
+    [Test]
+    public void AddConsumer_ReturnsBuilderForFluentChaining()
+    {
+        var result = _builder.AddConsumer<TestMessage, TestMessageHandler>("test.topic", "test-queue");
+
+        Assert.That(result, Is.SameAs(_builder));
+    }
+
+    [Test]
+    public void AddConsumer_MultipleConsumers_RegistersAll()
+    {
+        _builder
+            .AddConsumer<TestMessage, TestMessageHandler>("topic.one", "queue-one")
+            .AddConsumer<AnotherMessage, AnotherMessageHandler>("topic.two", "queue-two");
+
+        var provider = _services.BuildServiceProvider();
+        var registrations = provider.GetServices<RabbitMqConsumerRegistration>().ToList();
+
+        Assert.That(registrations, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void AddSpydersoftRabbitMq_RegistersMessagePublisherAsSingleton()
+    {
+        var descriptor = _services.FirstOrDefault(d => d.ServiceType == typeof(IMessagePublisher));
+
+        Assert.That(descriptor, Is.Not.Null);
+        Assert.That(descriptor!.Lifetime, Is.EqualTo(ServiceLifetime.Singleton));
+    }
+
+    [Test]
+    public void AddSpydersoftRabbitMq_RegistersConsumerBackgroundService()
+    {
+        var descriptor = _services.FirstOrDefault(d =>
+            d.ImplementationType == typeof(RabbitMqConsumerBackgroundService));
+
+        Assert.That(descriptor, Is.Not.Null);
+    }
+
+    [Test]
+    public void AddSpydersoftRabbitMq_ReturnsBuilder()
+    {
+        Assert.That(_builder, Is.Not.Null);
+        Assert.That(_builder.Services, Is.SameAs(_services));
+    }
+
+    private sealed class TestMessage { }
+    private sealed class AnotherMessage { }
+
+    private sealed class TestMessageHandler : IMessageHandler<TestMessage>
+    {
+        public Task HandleAsync(MessageEnvelope<TestMessage> envelope, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class AnotherMessageHandler : IMessageHandler<AnotherMessage>
+    {
+        public Task HandleAsync(MessageEnvelope<AnotherMessage> envelope, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/BuilderTests/AddConsumerTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/BuilderTests/AddConsumerTests.cs
@@ -38,10 +38,13 @@ internal class AddConsumerTests
         var registrations = provider.GetServices<RabbitMqConsumerRegistration>().ToList();
 
         Assert.That(registrations, Has.Count.EqualTo(1));
-        Assert.That(registrations[0].Topic, Is.EqualTo("test.topic"));
-        Assert.That(registrations[0].QueueName, Is.EqualTo("test-queue"));
-        Assert.That(registrations[0].MessageType, Is.EqualTo(typeof(TestMessage)));
-        Assert.That(registrations[0].HandlerType, Is.EqualTo(typeof(TestMessageHandler)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registrations[0].Topic, Is.EqualTo("test.topic"));
+            Assert.That(registrations[0].QueueName, Is.EqualTo("test-queue"));
+            Assert.That(registrations[0].MessageType, Is.EqualTo(typeof(TestMessage)));
+            Assert.That(registrations[0].HandlerType, Is.EqualTo(typeof(TestMessageHandler)));
+        }
     }
 
     [Test]

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/OptionsTests/RabbitMqOptionsDefaultsTests.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/OptionsTests/RabbitMqOptionsDefaultsTests.cs
@@ -1,0 +1,51 @@
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ.UnitTests.OptionsTests;
+
+internal class RabbitMqOptionsDefaultsTests
+{
+    private RabbitMqOptions _options = null!;
+
+    [SetUp]
+    public void SetUp() => _options = new RabbitMqOptions();
+
+    [Test]
+    public void SectionName_IsRabbitMq() =>
+        Assert.That(RabbitMqOptions.SectionName, Is.EqualTo("RabbitMq"));
+
+    [Test]
+    public void Host_DefaultsToLocalhost() =>
+        Assert.That(_options.Host, Is.EqualTo("localhost"));
+
+    [Test]
+    public void Port_DefaultsTo5672() =>
+        Assert.That(_options.Port, Is.EqualTo(5672));
+
+    [Test]
+    public void VirtualHost_DefaultsToSlash() =>
+        Assert.That(_options.VirtualHost, Is.EqualTo("/"));
+
+    [Test]
+    public void Username_DefaultsToGuest() =>
+        Assert.That(_options.Username, Is.EqualTo("guest"));
+
+    [Test]
+    public void Password_DefaultsToGuest() =>
+        Assert.That(_options.Password, Is.EqualTo("guest"));
+
+    [Test]
+    public void Exchange_DefaultsToSpydersoftMessaging() =>
+        Assert.That(_options.Exchange, Is.EqualTo("spydersoft.messaging"));
+
+    [Test]
+    public void ExchangeType_DefaultsToTopic() =>
+        Assert.That(_options.ExchangeType, Is.EqualTo("topic"));
+
+    [Test]
+    public void DurableExchange_DefaultsToTrue() =>
+        Assert.That(_options.DurableExchange, Is.True);
+
+    [Test]
+    public void PersistentMessages_DefaultsToTrue() =>
+        Assert.That(_options.PersistentMessages, Is.True);
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/Spydersoft.Messaging.RabbitMQ.UnitTests.csproj
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/Spydersoft.Messaging.RabbitMQ.UnitTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<RunSettingsFilePath>$(MSBuildThisFileDirectory)\coverlet.runsettings</RunSettingsFilePath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NUnit" />
+		<PackageReference Include="NUnit.Analyzers">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Spydersoft.Messaging.RabbitMQ\Spydersoft.Messaging.RabbitMQ.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="NUnit.Framework" />
+	</ItemGroup>
+
+</Project>

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/coverlet.runsettings
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/coverlet.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover,cobertura</Format>
+          <Exclude>[Spydersoft.Messaging.RabbitMQ.UnitTests]*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>false</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SkipAutoProps>false</SkipAutoProps>
+          <DeterministicReport>false</DeterministicReport>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Options/RabbitMqOptions.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Options/RabbitMqOptions.cs
@@ -1,0 +1,32 @@
+namespace Spydersoft.Messaging.RabbitMQ.Options;
+
+public class RabbitMqOptions
+{
+    public const string SectionName = "RabbitMq";
+
+    public string Host { get; set; } = "localhost";
+    public int Port { get; set; } = 5672;
+    public string VirtualHost { get; set; } = "/";
+    public string Username { get; set; } = "guest";
+    public string Password { get; set; } = "guest";
+
+    /// <summary>
+    /// Exchange to publish messages to.
+    /// </summary>
+    public string Exchange { get; set; } = "spydersoft.messaging";
+
+    /// <summary>
+    /// Exchange type: "direct", "topic", "fanout", "headers".
+    /// </summary>
+    public string ExchangeType { get; set; } = "topic";
+
+    /// <summary>
+    /// Whether the exchange should survive broker restarts.
+    /// </summary>
+    public bool DurableExchange { get; set; } = true;
+
+    /// <summary>
+    /// Whether published messages are persisted to disk.
+    /// </summary>
+    public bool PersistentMessages { get; set; } = true;
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Options/RabbitMqOptions.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Options/RabbitMqOptions.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Spydersoft.Messaging.RabbitMQ.Options;
 
 public class RabbitMqOptions
@@ -29,4 +31,12 @@ public class RabbitMqOptions
     /// Whether published messages are persisted to disk.
     /// </summary>
     public bool PersistentMessages { get; set; } = true;
+
+    /// <summary>
+    /// JSON serializer options used for envelope serialization. Defaults to
+    /// <see cref="JsonSerializerDefaults.Web"/> (camelCase property names). Both
+    /// publisher and consumer use the same instance, so the round-trip stays consistent.
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions { get; set; }
+        = new(JsonSerializerDefaults.Web);
 }

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerBackgroundService.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerBackgroundService.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ;
+
+public sealed class RabbitMqConsumerBackgroundService : BackgroundService
+{
+    private readonly IEnumerable<RabbitMqConsumerRegistration> _registrations;
+    private readonly RabbitMqOptions _options;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<RabbitMqConsumerBackgroundService> _logger;
+
+    private IConnection? _connection;
+    private readonly List<IChannel> _channels = [];
+
+    public RabbitMqConsumerBackgroundService(
+        IEnumerable<RabbitMqConsumerRegistration> registrations,
+        IOptions<RabbitMqOptions> options,
+        IServiceProvider serviceProvider,
+        ILogger<RabbitMqConsumerBackgroundService> logger)
+    {
+        _registrations = registrations;
+        _options = options.Value;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = _options.Host,
+            Port = _options.Port,
+            VirtualHost = _options.VirtualHost,
+            UserName = _options.Username,
+            Password = _options.Password
+        };
+
+        _connection = await factory.CreateConnectionAsync(stoppingToken);
+        _logger.LogInformation("RabbitMQ consumer connection established to {Host}:{Port}", _options.Host, _options.Port);
+
+        foreach (var registration in _registrations)
+        {
+            var channel = await _connection.CreateChannelAsync(cancellationToken: stoppingToken);
+            _channels.Add(channel);
+
+            await channel.ExchangeDeclareAsync(
+                exchange: _options.Exchange,
+                type: _options.ExchangeType,
+                durable: _options.DurableExchange,
+                autoDelete: false,
+                cancellationToken: stoppingToken);
+
+            await channel.QueueDeclareAsync(
+                queue: registration.QueueName,
+                durable: true,
+                exclusive: false,
+                autoDelete: false,
+                cancellationToken: stoppingToken);
+
+            await channel.QueueBindAsync(
+                queue: registration.QueueName,
+                exchange: _options.Exchange,
+                routingKey: registration.Topic,
+                cancellationToken: stoppingToken);
+
+            var consumer = new AsyncEventingBasicConsumer(channel);
+            consumer.ReceivedAsync += async (_, ea) =>
+            {
+                await HandleMessageAsync(ea, channel, registration, stoppingToken);
+            };
+
+            await channel.BasicConsumeAsync(
+                queue: registration.QueueName,
+                autoAck: false,
+                consumer: consumer,
+                cancellationToken: stoppingToken);
+
+            _logger.LogInformation(
+                "Consuming topic {Topic} from queue {Queue}",
+                registration.Topic, registration.QueueName);
+        }
+
+        await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+    }
+
+    private async Task HandleMessageAsync(
+        BasicDeliverEventArgs ea,
+        IChannel channel,
+        RabbitMqConsumerRegistration registration,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var envelopeType = typeof(MessageEnvelope<>).MakeGenericType(registration.MessageType);
+            var envelope = JsonSerializer.Deserialize(ea.Body.Span, envelopeType);
+
+            using var scope = _serviceProvider.CreateScope();
+            var handlerType = typeof(IMessageHandler<>).MakeGenericType(registration.MessageType);
+            var handler = scope.ServiceProvider.GetRequiredService(handlerType);
+
+            var handleMethod = handlerType.GetMethod(nameof(IMessageHandler<object>.HandleAsync))!;
+            await (Task) handleMethod.Invoke(handler, [envelope, cancellationToken])!;
+
+            await channel.BasicAckAsync(ea.DeliveryTag, multiple: false, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling message on topic {Topic}", registration.Topic);
+            await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, cancellationToken: cancellationToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await base.StopAsync(cancellationToken);
+
+        foreach (var channel in _channels)
+        {
+            await channel.CloseAsync(cancellationToken);
+            channel.Dispose();
+        }
+        _channels.Clear();
+
+        if (_connection is not null)
+        {
+            await _connection.CloseAsync(cancellationToken);
+            _connection.Dispose();
+        }
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerBackgroundService.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerBackgroundService.cs
@@ -99,7 +99,7 @@ public sealed class RabbitMqConsumerBackgroundService : BackgroundService
         try
         {
             var envelopeType = typeof(MessageEnvelope<>).MakeGenericType(registration.MessageType);
-            var envelope = JsonSerializer.Deserialize(ea.Body.Span, envelopeType);
+            var envelope = JsonSerializer.Deserialize(ea.Body.Span, envelopeType, _options.JsonSerializerOptions);
 
             using var scope = _serviceProvider.CreateScope();
             var handlerType = typeof(IMessageHandler<>).MakeGenericType(registration.MessageType);
@@ -109,6 +109,10 @@ public sealed class RabbitMqConsumerBackgroundService : BackgroundService
             await (Task) handleMethod.Invoke(handler, [envelope, cancellationToken])!;
 
             await channel.BasicAckAsync(ea.DeliveryTag, multiple: false, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerBackgroundService.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerBackgroundService.cs
@@ -9,7 +9,7 @@ using Spydersoft.Messaging.RabbitMQ.Options;
 
 namespace Spydersoft.Messaging.RabbitMQ;
 
-public sealed class RabbitMqConsumerBackgroundService : BackgroundService
+public sealed partial class RabbitMqConsumerBackgroundService : BackgroundService
 {
     private readonly IEnumerable<RabbitMqConsumerRegistration> _registrations;
     private readonly RabbitMqOptions _options;
@@ -43,7 +43,7 @@ public sealed class RabbitMqConsumerBackgroundService : BackgroundService
         };
 
         _connection = await factory.CreateConnectionAsync(stoppingToken);
-        _logger.LogInformation("RabbitMQ consumer connection established to {Host}:{Port}", _options.Host, _options.Port);
+        LogConsumerConnectionEstablished(_options.Host, _options.Port);
 
         foreach (var registration in _registrations)
         {
@@ -82,9 +82,7 @@ public sealed class RabbitMqConsumerBackgroundService : BackgroundService
                 consumer: consumer,
                 cancellationToken: stoppingToken);
 
-            _logger.LogInformation(
-                "Consuming topic {Topic} from queue {Queue}",
-                registration.Topic, registration.QueueName);
+            LogConsumingTopic(registration.Topic, registration.QueueName);
         }
 
         await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
@@ -138,4 +136,10 @@ public sealed class RabbitMqConsumerBackgroundService : BackgroundService
             _connection.Dispose();
         }
     }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "RabbitMQ consumer connection established to {Host}:{Port}")]
+    private partial void LogConsumerConnectionEstablished(string host, int port);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Consuming topic {Topic} from queue {Queue}")]
+    private partial void LogConsumingTopic(string topic, string queue);
 }

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerRegistration.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqConsumerRegistration.cs
@@ -1,0 +1,8 @@
+namespace Spydersoft.Messaging.RabbitMQ;
+
+public sealed record RabbitMqConsumerRegistration(
+    string Topic,
+    string QueueName,
+    Type MessageType,
+    Type HandlerType
+);

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagePublisher.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagePublisher.cs
@@ -37,12 +37,18 @@ public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposab
             autoDelete: false,
             cancellationToken: cancellationToken);
 
-        var body = JsonSerializer.SerializeToUtf8Bytes(envelope);
+        var body = JsonSerializer.SerializeToUtf8Bytes(envelope, _options.JsonSerializerOptions);
 
         var properties = new BasicProperties
         {
-            DeliveryMode = _options.PersistentMessages ? DeliveryModes.Persistent : DeliveryModes.Transient
+            DeliveryMode = _options.PersistentMessages ? DeliveryModes.Persistent : DeliveryModes.Transient,
+            ContentType = "application/json",
+            MessageId = envelope.MessageId,
         };
+        if (!string.IsNullOrEmpty(envelope.CorrelationId))
+        {
+            properties.CorrelationId = envelope.CorrelationId;
+        }
 
         await channel.BasicPublishAsync(
             exchange: _options.Exchange,

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagePublisher.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagePublisher.cs
@@ -6,7 +6,7 @@ using Spydersoft.Messaging.RabbitMQ.Options;
 
 namespace Spydersoft.Messaging.RabbitMQ;
 
-public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposable
+public sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposable
 {
     private readonly RabbitMqOptions _options;
     private readonly ILogger<RabbitMqMessagePublisher> _logger;
@@ -58,7 +58,7 @@ public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposab
             body: body,
             cancellationToken: cancellationToken);
 
-        _logger.LogDebug("Published message to topic {Topic} on exchange {Exchange}", topic, _options.Exchange);
+        LogPublished(topic, _options.Exchange);
     }
 
     private async Task<IConnection> GetOrCreateConnectionAsync(CancellationToken cancellationToken)
@@ -86,7 +86,7 @@ public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposab
             };
 
             _connection = await factory.CreateConnectionAsync(cancellationToken);
-            _logger.LogInformation("RabbitMQ connection established to {Host}:{Port}", _options.Host, _options.Port);
+            LogConnectionEstablished(_options.Host, _options.Port);
             return _connection;
         }
         finally
@@ -104,4 +104,10 @@ public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposab
         }
         _connectionLock.Dispose();
     }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Debug, Message = "Published message to topic {Topic} on exchange {Exchange}")]
+    private partial void LogPublished(string topic, string exchange);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "RabbitMQ connection established to {Host}:{Port}")]
+    private partial void LogConnectionEstablished(string host, int port);
 }

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagePublisher.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagePublisher.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ;
+
+public sealed class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposable
+{
+    private readonly RabbitMqOptions _options;
+    private readonly ILogger<RabbitMqMessagePublisher> _logger;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private IConnection? _connection;
+
+    public RabbitMqMessagePublisher(IOptions<RabbitMqOptions> options, ILogger<RabbitMqMessagePublisher> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task PublishAsync<T>(string topic, T message, CancellationToken cancellationToken = default)
+    {
+        var envelope = new MessageEnvelope<T> { Payload = message, Topic = topic };
+        return PublishAsync(topic, envelope, cancellationToken);
+    }
+
+    public async Task PublishAsync<T>(string topic, MessageEnvelope<T> envelope, CancellationToken cancellationToken = default)
+    {
+        var connection = await GetOrCreateConnectionAsync(cancellationToken);
+        await using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
+
+        await channel.ExchangeDeclareAsync(
+            exchange: _options.Exchange,
+            type: _options.ExchangeType,
+            durable: _options.DurableExchange,
+            autoDelete: false,
+            cancellationToken: cancellationToken);
+
+        var body = JsonSerializer.SerializeToUtf8Bytes(envelope);
+
+        var properties = new BasicProperties
+        {
+            DeliveryMode = _options.PersistentMessages ? DeliveryModes.Persistent : DeliveryModes.Transient
+        };
+
+        await channel.BasicPublishAsync(
+            exchange: _options.Exchange,
+            routingKey: topic,
+            mandatory: false,
+            basicProperties: properties,
+            body: body,
+            cancellationToken: cancellationToken);
+
+        _logger.LogDebug("Published message to topic {Topic} on exchange {Exchange}", topic, _options.Exchange);
+    }
+
+    private async Task<IConnection> GetOrCreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        if (_connection is { IsOpen: true })
+        {
+            return _connection;
+        }
+
+        await _connectionLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_connection is { IsOpen: true })
+            {
+                return _connection;
+            }
+
+            var factory = new ConnectionFactory
+            {
+                HostName = _options.Host,
+                Port = _options.Port,
+                VirtualHost = _options.VirtualHost,
+                UserName = _options.Username,
+                Password = _options.Password
+            };
+
+            _connection = await factory.CreateConnectionAsync(cancellationToken);
+            _logger.LogInformation("RabbitMQ connection established to {Host}:{Port}", _options.Host, _options.Port);
+            return _connection;
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
+        {
+            await _connection.CloseAsync();
+            _connection.Dispose();
+        }
+        _connectionLock.Dispose();
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagingBuilderExtensions.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagingBuilderExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Spydersoft.Messaging.RabbitMQ.Options;
+
+namespace Spydersoft.Messaging.RabbitMQ;
+
+public static class RabbitMqMessagingBuilderExtensions
+{
+    /// <summary>
+    /// Adds the RabbitMQ transport for Spydersoft.Messaging, binding options from configuration.
+    /// </summary>
+    public static ISpydersoftMessagingBuilder AddSpydersoftRabbitMq(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<RabbitMqOptions>(configuration.GetSection(RabbitMqOptions.SectionName));
+        return RegisterCommon(services);
+    }
+
+    /// <summary>
+    /// Adds the RabbitMQ transport for Spydersoft.Messaging with inline options configuration.
+    /// </summary>
+    public static ISpydersoftMessagingBuilder AddSpydersoftRabbitMq(
+        this IServiceCollection services,
+        Action<RabbitMqOptions> configure)
+    {
+        services.Configure(configure);
+        return RegisterCommon(services);
+    }
+
+    private static ISpydersoftMessagingBuilder RegisterCommon(IServiceCollection services)
+    {
+        services.AddSingleton<IMessagePublisher, RabbitMqMessagePublisher>();
+        services.AddHostedService<RabbitMqConsumerBackgroundService>();
+        return new SpydersoftMessagingBuilder(services);
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagingBuilderExtensions.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/RabbitMqMessagingBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class RabbitMqMessagingBuilderExtensions
         return RegisterCommon(services);
     }
 
-    private static ISpydersoftMessagingBuilder RegisterCommon(IServiceCollection services)
+    private static SpydersoftMessagingBuilder RegisterCommon(IServiceCollection services)
     {
         services.AddSingleton<IMessagePublisher, RabbitMqMessagePublisher>();
         services.AddHostedService<RabbitMqConsumerBackgroundService>();

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.csproj
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageDescription>RabbitMQ transport implementation for Spydersoft.Messaging.</PackageDescription>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="RabbitMQ.Client" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Options" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\Spydersoft.Messaging\Spydersoft.Messaging\Spydersoft.Messaging.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="../docs/README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+</Project>

--- a/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/SpydersoftMessagingBuilder.cs
+++ b/src/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/SpydersoftMessagingBuilder.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Spydersoft.Messaging.RabbitMQ;
+
+internal sealed class SpydersoftMessagingBuilder : ISpydersoftMessagingBuilder
+{
+    public IServiceCollection Services { get; }
+
+    public SpydersoftMessagingBuilder(IServiceCollection services)
+    {
+        Services = services;
+    }
+
+    public ISpydersoftMessagingBuilder AddConsumer<TMessage, THandler>(string topic, string queueName)
+        where THandler : class, IMessageHandler<TMessage>
+    {
+        Services.AddScoped<IMessageHandler<TMessage>, THandler>();
+        Services.AddSingleton(new RabbitMqConsumerRegistration(
+            Topic: topic,
+            QueueName: queueName,
+            MessageType: typeof(TMessage),
+            HandlerType: typeof(THandler)));
+
+        return this;
+    }
+}

--- a/src/Spydersoft.Messaging.RabbitMQ/docs/README.md
+++ b/src/Spydersoft.Messaging.RabbitMQ/docs/README.md
@@ -71,3 +71,21 @@ public sealed class MyMessageHandler : IMessageHandler<MyMessage>
 ```
 
 Unhandled exceptions result in a nack without requeue, routing the message to the dead-letter exchange if configured on the broker.
+
+## Failure Semantics
+
+- **Publishing** (`IMessagePublisher.PublishAsync`): throws on transport failure. Callers
+  that need fire-and-forget semantics (e.g. logging audit events) must wrap the call in
+  their own try/catch.
+- **Consuming** (`IMessageHandler<T>.HandleAsync`): an unhandled exception causes the
+  underlying transport to nack the message without requeue, routing to the dead-letter
+  exchange if the broker has one configured.
+- **Cancellation**: handlers should respect `CancellationToken` and propagate
+  `OperationCanceledException` on shutdown — the transport will release in-flight messages
+  back to the queue.
+
+## JSON Serialization
+
+Envelopes are serialized as JSON using `JsonSerializerDefaults.Web` by default (camelCase
+property names). To customize, set `RabbitMqOptions.JsonSerializerOptions` — both publisher
+and consumer use the same instance, so the round-trip stays consistent.

--- a/src/Spydersoft.Messaging.RabbitMQ/docs/README.md
+++ b/src/Spydersoft.Messaging.RabbitMQ/docs/README.md
@@ -1,0 +1,73 @@
+# Spydersoft.Messaging.RabbitMQ
+
+RabbitMQ transport implementation for `Spydersoft.Messaging`.
+
+## Overview
+
+This package wires up `IMessagePublisher` and a hosted consumer service backed by [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client). It requires `Spydersoft.Messaging` for the core interfaces.
+
+## Configuration
+
+Add a `RabbitMq` section to `appsettings.json`:
+
+```json
+{
+  "RabbitMq": {
+    "Host": "localhost",
+    "Port": 5672,
+    "Username": "guest",
+    "Password": "guest",
+    "Exchange": "spydersoft.messaging",
+    "ExchangeType": "topic",
+    "DurableExchange": true,
+    "PersistentMessages": true
+  }
+}
+```
+
+## Registration
+
+```csharp
+services
+    .AddSpydersoftMessaging()
+    .AddSpydersoftRabbitMq(configuration)
+    .AddConsumer<MyMessage, MyMessageHandler>(
+        topic: "my.topic",
+        queueName: "my-service.my-queue");
+```
+
+Or configure inline:
+
+```csharp
+services
+    .AddSpydersoftMessaging()
+    .AddSpydersoftRabbitMq(opts =>
+    {
+        opts.Host = "rabbitmq";
+        opts.Exchange = "my-exchange";
+    });
+```
+
+## Publishing
+
+Inject `IMessagePublisher`:
+
+```csharp
+await publisher.PublishAsync("my.topic", new MyMessage { ... });
+```
+
+## Consuming
+
+Implement `IMessageHandler<T>` and register with `AddConsumer`. The background service handles connection lifecycle, deserialization, ack/nack, and scoped handler resolution automatically.
+
+```csharp
+public sealed class MyMessageHandler : IMessageHandler<MyMessage>
+{
+    public async Task HandleAsync(MessageEnvelope<MyMessage> envelope, CancellationToken cancellationToken)
+    {
+        // process envelope.Payload
+    }
+}
+```
+
+Unhandled exceptions result in a nack without requeue, routing the message to the dead-letter exchange if configured on the broker.

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/MessageEnvelopeTests/DefaultValueTests.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/MessageEnvelopeTests/DefaultValueTests.cs
@@ -9,8 +9,11 @@ internal class DefaultValueTests
     {
         var envelope = new MessageEnvelope<string> { Payload = "test" };
 
-        Assert.That(envelope.MessageId, Is.Not.Null.And.Not.Empty);
-        Assert.That(Guid.TryParse(envelope.MessageId, out _), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(envelope.MessageId, Is.Not.Null.And.Not.Empty);
+            Assert.That(Guid.TryParse(envelope.MessageId, out _), Is.True);
+        }
     }
 
     [Test]
@@ -20,9 +23,12 @@ internal class DefaultValueTests
         var envelope = new MessageEnvelope<string> { Payload = "test" };
         var after = DateTimeOffset.UtcNow;
 
-        Assert.That(envelope.PublishedAt.Offset, Is.EqualTo(TimeSpan.Zero));
-        Assert.That(envelope.PublishedAt, Is.GreaterThanOrEqualTo(before));
-        Assert.That(envelope.PublishedAt, Is.LessThanOrEqualTo(after));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(envelope.PublishedAt.Offset, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(envelope.PublishedAt, Is.GreaterThanOrEqualTo(before));
+            Assert.That(envelope.PublishedAt, Is.LessThanOrEqualTo(after));
+        }
     }
 
     [Test]

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/MessageEnvelopeTests/DefaultValueTests.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/MessageEnvelopeTests/DefaultValueTests.cs
@@ -1,0 +1,58 @@
+using Spydersoft.Messaging;
+
+namespace Spydersoft.Messaging.UnitTests.MessageEnvelopeTests;
+
+internal class DefaultValueTests
+{
+    [Test]
+    public void MessageId_IsValidNonEmptyGuid()
+    {
+        var envelope = new MessageEnvelope<string> { Payload = "test" };
+
+        Assert.That(envelope.MessageId, Is.Not.Null.And.Not.Empty);
+        Assert.That(Guid.TryParse(envelope.MessageId, out _), Is.True);
+    }
+
+    [Test]
+    public void PublishedAt_IsUtc()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var envelope = new MessageEnvelope<string> { Payload = "test" };
+        var after = DateTimeOffset.UtcNow;
+
+        Assert.That(envelope.PublishedAt.Offset, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(envelope.PublishedAt, Is.GreaterThanOrEqualTo(before));
+        Assert.That(envelope.PublishedAt, Is.LessThanOrEqualTo(after));
+    }
+
+    [Test]
+    public void OptionalFields_DefaultToNull()
+    {
+        var envelope = new MessageEnvelope<string> { Payload = "test" };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(envelope.CorrelationId, Is.Null);
+            Assert.That(envelope.Source, Is.Null);
+            Assert.That(envelope.Topic, Is.Null);
+        }
+    }
+
+    [Test]
+    public void EachInstance_HasUniqueMessageId()
+    {
+        var first = new MessageEnvelope<int> { Payload = 1 };
+        var second = new MessageEnvelope<int> { Payload = 2 };
+
+        Assert.That(first.MessageId, Is.Not.EqualTo(second.MessageId));
+    }
+
+    [Test]
+    public void Payload_IsPreserved()
+    {
+        var payload = new { Value = 42 };
+        var envelope = new MessageEnvelope<object> { Payload = payload };
+
+        Assert.That(envelope.Payload, Is.SameAs(payload));
+    }
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/MessagingServiceCollectionExtensionsTests/AddSpydersoftMessagingTests.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/MessagingServiceCollectionExtensionsTests/AddSpydersoftMessagingTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+using Spydersoft.Messaging;
+
+namespace Spydersoft.Messaging.UnitTests.MessagingServiceCollectionExtensionsTests;
+
+internal class AddSpydersoftMessagingTests
+{
+    [Test]
+    public void AddSpydersoftMessaging_ReturnsSameServiceCollection()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddSpydersoftMessaging();
+
+        Assert.That(result, Is.SameAs(services));
+    }
+
+    [Test]
+    public void AddSpydersoftMessaging_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+
+        Assert.DoesNotThrow(() => services.AddSpydersoftMessaging());
+    }
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/Spydersoft.Messaging.UnitTests.csproj
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/Spydersoft.Messaging.UnitTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<RunSettingsFilePath>$(MSBuildThisFileDirectory)\coverlet.runsettings</RunSettingsFilePath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NUnit" />
+		<PackageReference Include="NUnit.Analyzers">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Spydersoft.Messaging\Spydersoft.Messaging.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="NUnit.Framework" />
+	</ItemGroup>
+
+</Project>

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/coverlet.runsettings
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/coverlet.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover,cobertura</Format>
+          <Exclude>[Spydersoft.Messaging.UnitTests]*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>false</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SkipAutoProps>false</SkipAutoProps>
+          <DeterministicReport>false</DeterministicReport>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging/IMessageHandler.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging/IMessageHandler.cs
@@ -1,0 +1,6 @@
+namespace Spydersoft.Messaging;
+
+public interface IMessageHandler<T>
+{
+    Task HandleAsync(MessageEnvelope<T> envelope, CancellationToken cancellationToken = default);
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging/IMessagePublisher.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging/IMessagePublisher.cs
@@ -1,0 +1,16 @@
+namespace Spydersoft.Messaging;
+
+public interface IMessagePublisher
+{
+    /// <summary>
+    /// Publishes a message to the specified topic.
+    /// The message is wrapped in a <see cref="MessageEnvelope{T}"/> by the implementation.
+    /// </summary>
+    Task PublishAsync<T>(string topic, T message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a pre-built envelope to the specified topic.
+    /// Use this overload when you need to control envelope metadata (e.g. CorrelationId).
+    /// </summary>
+    Task PublishAsync<T>(string topic, MessageEnvelope<T> envelope, CancellationToken cancellationToken = default);
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging/ISpydersoftMessagingBuilder.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging/ISpydersoftMessagingBuilder.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Spydersoft.Messaging;
+
+public interface ISpydersoftMessagingBuilder
+{
+    IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Registers a typed message handler for the given topic.
+    /// A dedicated queue named <paramref name="queueName"/> is declared and bound to the topic.
+    /// </summary>
+    ISpydersoftMessagingBuilder AddConsumer<TMessage, THandler>(string topic, string queueName)
+        where THandler : class, IMessageHandler<TMessage>;
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging/MessageEnvelope.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging/MessageEnvelope.cs
@@ -1,0 +1,11 @@
+namespace Spydersoft.Messaging;
+
+public sealed class MessageEnvelope<T>
+{
+    public required T Payload { get; init; }
+    public string MessageId { get; init; } = Guid.NewGuid().ToString();
+    public DateTimeOffset PublishedAt { get; init; } = DateTimeOffset.UtcNow;
+    public string? CorrelationId { get; init; }
+    public string? Source { get; init; }
+    public string? Topic { get; init; }
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging/MessagingServiceCollectionExtensions.cs
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging/MessagingServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Spydersoft.Messaging;
+
+public static class MessagingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers Spydersoft.Messaging core services.
+    /// Call this before adding a transport implementation (e.g. AddSpydersoftRabbitMq).
+    /// </summary>
+    public static IServiceCollection AddSpydersoftMessaging(this IServiceCollection services)
+    {
+        // No-op placeholder; provides a consistent registration entry point
+        // and a place to add cross-cutting concerns (e.g. middleware pipeline, metrics) later.
+        return services;
+    }
+}

--- a/src/Spydersoft.Messaging/Spydersoft.Messaging/Spydersoft.Messaging.csproj
+++ b/src/Spydersoft.Messaging/Spydersoft.Messaging/Spydersoft.Messaging.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageDescription>Transport-agnostic messaging abstractions for the Spydersoft Platform.</PackageDescription>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="../docs/README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+</Project>

--- a/src/Spydersoft.Messaging/docs/README.md
+++ b/src/Spydersoft.Messaging/docs/README.md
@@ -56,3 +56,15 @@ public sealed class MyMessageHandler : IMessageHandler<MyMessage>
     }
 }
 ```
+
+## Failure Semantics
+
+- **Publishing** (`IMessagePublisher.PublishAsync`): throws on transport failure. Callers
+  that need fire-and-forget semantics (e.g. logging audit events) must wrap the call in
+  their own try/catch.
+- **Consuming** (`IMessageHandler<T>.HandleAsync`): an unhandled exception causes the
+  underlying transport to nack the message without requeue, routing to the dead-letter
+  exchange if the broker has one configured.
+- **Cancellation**: handlers should respect `CancellationToken` and propagate
+  `OperationCanceledException` on shutdown — the transport will release in-flight messages
+  back to the queue.

--- a/src/Spydersoft.Messaging/docs/README.md
+++ b/src/Spydersoft.Messaging/docs/README.md
@@ -1,0 +1,58 @@
+# Spydersoft.Messaging
+
+Transport-agnostic messaging abstractions for the Spydersoft Platform.
+
+## Overview
+
+This package provides the core interfaces and contracts for messaging. It has no transport dependency — add a transport package such as `Spydersoft.Messaging.RabbitMQ` to wire up a concrete implementation.
+
+## Core Types
+
+| Type | Description |
+|---|---|
+| `MessageEnvelope<T>` | Wraps a payload with routing and observability metadata. |
+| `IMessagePublisher` | Publishes messages to a named topic. |
+| `IMessageHandler<T>` | Implemented by consumers to process a specific message type. |
+| `ISpydersoftMessagingBuilder` | Fluent builder returned by transport registration methods. |
+
+## Getting Started
+
+```csharp
+// In Program.cs / Startup.cs
+services
+    .AddSpydersoftMessaging()
+    .AddSpydersoftRabbitMq(configuration)
+    .AddConsumer<MyMessage, MyMessageHandler>(
+        topic: "my.topic",
+        queueName: "my-service.my-queue");
+```
+
+## Publishing Messages
+
+Inject `IMessagePublisher` and call `PublishAsync`:
+
+```csharp
+await publisher.PublishAsync("my.topic", new MyMessage { ... });
+
+// Or supply a pre-built envelope to control metadata:
+var envelope = new MessageEnvelope<MyMessage>
+{
+    Payload = new MyMessage { ... },
+    CorrelationId = Activity.Current?.TraceId.ToString()
+};
+await publisher.PublishAsync("my.topic", envelope);
+```
+
+## Consuming Messages
+
+Implement `IMessageHandler<T>` and register it via `AddConsumer`:
+
+```csharp
+public sealed class MyMessageHandler : IMessageHandler<MyMessage>
+{
+    public async Task HandleAsync(MessageEnvelope<MyMessage> envelope, CancellationToken cancellationToken)
+    {
+        // process envelope.Payload
+    }
+}
+```

--- a/src/Spydersoft.Platform.slnx
+++ b/src/Spydersoft.Platform.slnx
@@ -3,6 +3,14 @@
     <Project Path="Spydersoft.Platform/Spydersoft.Platform.UnitTests/Spydersoft.Platform.UnitTests.csproj" />
     <Project Path="Spydersoft.Platform/Spydersoft.Platform/Spydersoft.Platform.csproj" />
   </Folder>
+  <Folder Name="/Messaging/">
+    <Project Path="Spydersoft.Messaging/Spydersoft.Messaging/Spydersoft.Messaging.csproj" />
+    <Project Path="Spydersoft.Messaging/Spydersoft.Messaging.UnitTests/Spydersoft.Messaging.UnitTests.csproj" />
+  </Folder>
+  <Folder Name="/Messaging.RabbitMQ/">
+    <Project Path="Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.csproj" />
+    <Project Path="Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/Spydersoft.Messaging.RabbitMQ.UnitTests.csproj" />
+  </Folder>
   <Folder Name="/Hosting/">
     <Project Path="Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Spydersoft.Platform.Hosting.ApiTests.csproj" />
     <Project Path="Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.UnitTests/Spydersoft.Platform.Hosting.UnitTests.csproj" />

--- a/src/Spydersoft.Platform.slnx
+++ b/src/Spydersoft.Platform.slnx
@@ -10,6 +10,7 @@
   <Folder Name="/Messaging.RabbitMQ/">
     <Project Path="Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.csproj" />
     <Project Path="Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.UnitTests/Spydersoft.Messaging.RabbitMQ.UnitTests.csproj" />
+    <Project Path="Spydersoft.Messaging.RabbitMQ/Spydersoft.Messaging.RabbitMQ.IntegrationTests/Spydersoft.Messaging.RabbitMQ.IntegrationTests.csproj" />
   </Folder>
   <Folder Name="/Hosting/">
     <Project Path="Spydersoft.Platform.Hosting/Spydersoft.Platform.Hosting.ApiTests/Spydersoft.Platform.Hosting.ApiTests.csproj" />


### PR DESCRIPTION
This pull request introduces integration tests for the new `Spydersoft.Messaging.RabbitMQ` library, updates the build pipeline to include integration tests, and adds relevant dependencies. The changes ensure that messaging functionality is thoroughly tested against a real RabbitMQ broker using containerized infrastructure, and that code quality metrics reflect the new tests.

**Integration Test Infrastructure and Coverage**

* Added a new test project `Spydersoft.Messaging.RabbitMQ.IntegrationTests` with multiple test classes covering message publishing/consuming, acknowledgement/nack logic, message property serialization, and custom JSON serializer options. These tests use NUnit and run against a real RabbitMQ broker provisioned via the `Testcontainers.RabbitMq` library. [[1]](diffhunk://#diff-c3bdce2c8c91811206f12f040203cc390d679bee552e6f6d19c9c820b3a9c365R1-R36) [[2]](diffhunk://#diff-2785d0c0977b80ea62857a460b825e459a67f4ab6cac2047d0435c515bc9e2e1R1-R37) [[3]](diffhunk://#diff-69bc91bad76a6bf9aa6176525151c55757d9705c23945faa583fae3af67983e1R1-R68) [[4]](diffhunk://#diff-21902781343b8cc2ced3bcca81b8ea12a717dcb89ab05ef47d9b8ecce32265b9R1-R121) [[5]](diffhunk://#diff-86a280fb62beba09b6ef322595016c6183c43dd798b134b4c7cc44f57240b7e2R1-R111) [[6]](diffhunk://#diff-3bd2f3cc9c39f0f962410a0c34f9ba0bf604ba2b762360cf125872c766582e0eR1-R115)

* Updated `.devops/pipeline-main.yml` to include integration test projects in the test execution and to exclude their binaries from NuGet packaging. Also updated SonarQube configuration to include/exclude integration tests in test/coverage reporting. [[1]](diffhunk://#diff-155461a280258fc0370b150c753722ae705ac3295bf706078e0629f0c04efa4aL28-R32) [[2]](diffhunk://#diff-155461a280258fc0370b150c753722ae705ac3295bf706078e0629f0c04efa4aL55-R57)

**Dependency Management**

* Added messaging and test dependencies (e.g., `RabbitMQ.Client`, `Testcontainers.RabbitMq`, `Microsoft.Extensions.*`) to `Directory.Packages.props` to support the new integration test suite and messaging library. [[1]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11R40-R49) [[2]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11R59)

**Documentation**

* Updated the `README.md` to include the new `Spydersoft.Messaging` and `Spydersoft.Messaging.RabbitMQ` libraries in the list of available libraries.